### PR TITLE
5/15 winapi: return i16 from dllexports

### DIFF
--- a/win32/winapi/src/dllexport.rs
+++ b/win32/winapi/src/dllexport.rs
@@ -24,6 +24,13 @@ impl From<u16> for ABIReturn {
     }
 }
 
+impl From<i16> for ABIReturn {
+    fn from(value: i16) -> Self {
+        // Sign-extends, as a function returning SHORT does.
+        Self(value as i32 as u32)
+    }
+}
+
 impl From<bool> for ABIReturn {
     fn from(value: bool) -> Self {
         Self(if value { 1 } else { 0 })


### PR DESCRIPTION


Part 5 of 15, splitting up #1. Applies to main on its own and compiles.
