### PR TITLE
8/15 kernel32: resolve exports at runtime for LoadLibrary/GetProcAddress

### DIFF
--- a/out/mofo-unpack/src/main.rs
+++ b/out/mofo-unpack/src/main.rs
@@ -133,7 +133,7 @@ pub fn do_unpack(ctx: &mut runtime::Context) {
         code_memory: 0x40_0000..tc.mem.bytes.len() as u32,
         resources: None,
         imports: syms,
-        vtables: vec![],
+        ..Default::default()
     });
     tc.init_imports();
 

--- a/tc/src/codegen/mod.rs
+++ b/tc/src/codegen/mod.rs
@@ -363,6 +363,17 @@ out.copy_from_slice(bytes);",
                     }
                     self.line("}");
                 }
+                for (dll, func) in &module.dynamic_exports {
+                    let addr = module
+                        .imports
+                        .iter()
+                        .find(|imp| imp.dll == *dll && imp.func == *func)
+                        .expect("dynamic export without a reserved address")
+                        .addr;
+                    self.line(format!(
+                        "winapi::kernel32::register_export({dll:?}, {func:?}, {addr:#x});"
+                    ));
+                }
             }
             Module::DOS(module) => {
                 self.line(format!("

--- a/tc/src/exe.rs
+++ b/tc/src/exe.rs
@@ -83,6 +83,7 @@ fn load_pe(mem: &mut Memory, buf: &[u8], f: exe::PE) -> WindowsModule {
         code_memory: code_range.unwrap(),
         resources,
         vtables: Default::default(),
+        dynamic_exports: Default::default(),
     }
 }
 

--- a/tc/src/lib.rs
+++ b/tc/src/lib.rs
@@ -31,6 +31,8 @@ pub struct WindowsModule {
     pub resources: Option<std::ops::Range<u32>>,
     pub imports: Vec<Import>,
     pub vtables: Vec<(String, u32)>,
+    /// (dll, function) pairs the program may resolve through GetProcAddress.
+    pub dynamic_exports: Vec<(String, String)>,
 }
 
 #[derive(Debug, Clone)]
@@ -227,6 +229,38 @@ impl State {
                     });
                     addr += 4;
                 }
+            }
+        }
+
+        for (dll, funcs) in winapi::DYNAMIC_EXPORTS {
+            if !module.imports.iter().any(|imp| imp.dll == *dll) {
+                continue;
+            }
+            for func in funcs.iter() {
+                module
+                    .dynamic_exports
+                    .push((dll.to_string(), func.to_string()));
+                // A function already imported statically has an address
+                // already; only the rest need one reserved.
+                if module
+                    .imports
+                    .iter()
+                    .any(|imp| imp.dll == *dll && imp.func == *func)
+                {
+                    continue;
+                }
+                if addr == 0 {
+                    addr = self.mem.mappings.alloc("vtables".into(), 0x1000);
+                    assert!(addr != 0);
+                }
+                module.imports.push(Import {
+                    dll: dll.to_string(),
+                    func: func.to_string(),
+                    iat_addr: addr,
+                    addr: 0,
+                    data: false,
+                });
+                addr += 4;
             }
         }
 

--- a/win32/winapi/src/advapi32.rs
+++ b/win32/winapi/src/advapi32.rs
@@ -12,7 +12,11 @@ pub fn RegCloseKey(_ctx: &mut Context, _hKey: HKEY) -> u32 /* WIN32_ERROR */ {
 }
 
 #[win32_derive::dllexport]
-pub fn GetUserNameA(ctx: &mut Context, lpBuffer: crate::Ptr<u8>, pcbBuffer: crate::Ptr<u32>) -> bool {
+pub fn GetUserNameA(
+    ctx: &mut Context,
+    lpBuffer: crate::Ptr<u8>,
+    pcbBuffer: crate::Ptr<u32>,
+) -> bool {
     let name = b"user";
     let size = pcbBuffer.read(&ctx.memory).unwrap_or(0);
     if (size as usize) < name.len() + 1 {

--- a/win32/winapi/src/dinput.rs
+++ b/win32/winapi/src/dinput.rs
@@ -303,7 +303,13 @@ pub mod IDirectInputDevice {
     }
 
     #[win32_derive::dllexport]
-    pub fn GetObjectInfo(_ctx: &mut Context, _this: u32, _pdidoi: u32, _dwObj: u32, _dwHow: u32) -> u32 {
+    pub fn GetObjectInfo(
+        _ctx: &mut Context,
+        _this: u32,
+        _pdidoi: u32,
+        _dwObj: u32,
+        _dwHow: u32,
+    ) -> u32 {
         todo!()
     }
 
@@ -318,7 +324,13 @@ pub mod IDirectInputDevice {
     }
 
     #[win32_derive::dllexport]
-    pub fn Initialize(_ctx: &mut Context, _this: u32, _hinst: u32, _dwVersion: u32, _rguid: u32) -> u32 {
+    pub fn Initialize(
+        _ctx: &mut Context,
+        _this: u32,
+        _hinst: u32,
+        _dwVersion: u32,
+        _rguid: u32,
+    ) -> u32 {
         DI_OK
     }
 

--- a/win32/winapi/src/kernel32/dll.rs
+++ b/win32/winapi/src/kernel32/dll.rs
@@ -1,8 +1,10 @@
-use std::sync::Mutex;
-
 use runtime::Context;
 
-use crate::{Ptr, kernel32::lock, stub};
+use crate::{
+    Ptr,
+    kernel32::{State, lock},
+    stub,
+};
 
 pub type HMODULE = u32;
 
@@ -33,14 +35,12 @@ impl DLLLoader for () {
 /// uses for imports, so they resolve through the block table) and registers it
 /// here from the generated init code.
 #[derive(Default)]
-struct Exports {
+pub struct Exports {
     /// (dll, function) -> address, with dll lowercased and without ".dll".
     functions: Vec<(String, String, u32)>,
     /// Module handles handed out by LoadLibrary, in registration order.
     modules: Vec<String>,
 }
-
-static EXPORTS: Mutex<Option<Exports>> = Mutex::new(None);
 
 /// Module handles are synthetic; the value only has to be non-null and
 /// distinguishable.
@@ -53,40 +53,45 @@ fn normalize_module_name(name: &str) -> String {
     name.strip_suffix(".dll").unwrap_or(&name).to_string()
 }
 
-/// Register a function as available through GetProcAddress. Called from
-/// generated init code, once per function the translator reserved an address
-/// for.
-pub fn register_export(dll: &str, func: &str, addr: u32) {
-    let mut exports = EXPORTS.lock().unwrap();
-    let exports = exports.get_or_insert_with(Default::default);
-    let dll = normalize_module_name(dll);
-    if !exports.modules.contains(&dll) {
-        exports.modules.push(dll.clone());
+impl State {
+    /// Register a function as available through GetProcAddress. Called from
+    /// generated init code, once per function the translator reserved an
+    /// address for.
+    pub fn register_export(&mut self, dll: &str, func: &str, addr: u32) {
+        let dll = normalize_module_name(dll);
+        if !self.exports.modules.contains(&dll) {
+            self.exports.modules.push(dll.clone());
+        }
+        self.exports.functions.push((dll, func.to_string(), addr));
     }
-    exports.functions.push((dll, func.to_string(), addr));
+
+    fn module_handle(&self, name: &str) -> Option<HMODULE> {
+        let name = normalize_module_name(name);
+        let index = self
+            .exports
+            .modules
+            .iter()
+            .position(|module| *module == name)?;
+        Some(MODULE_HANDLE_BASE + index as u32)
+    }
+
+    fn module_name(&self, handle: HMODULE) -> Option<&str> {
+        let index = handle.checked_sub(MODULE_HANDLE_BASE)? as usize;
+        self.exports.modules.get(index).map(String::as_str)
+    }
+
+    fn proc_address(&self, module: &str, func: &str) -> Option<u32> {
+        self.exports
+            .functions
+            .iter()
+            .find_map(|(dll, name, addr)| (dll == module && name == func).then_some(*addr))
+    }
 }
 
-fn module_handle(name: &str) -> Option<HMODULE> {
-    let exports = EXPORTS.lock().unwrap();
-    let exports = exports.as_ref()?;
-    let name = normalize_module_name(name);
-    let index = exports.modules.iter().position(|module| *module == name)?;
-    Some(MODULE_HANDLE_BASE + index as u32)
-}
-
-fn module_name(handle: HMODULE) -> Option<String> {
-    let index = handle.checked_sub(MODULE_HANDLE_BASE)? as usize;
-    let exports = EXPORTS.lock().unwrap();
-    exports.as_ref()?.modules.get(index).cloned()
-}
-
-fn proc_address(module: &str, func: &str) -> Option<u32> {
-    let exports = EXPORTS.lock().unwrap();
-    exports
-        .as_ref()?
-        .functions
-        .iter()
-        .find_map(|(dll, name, addr)| (dll == module && name == func).then_some(*addr))
+/// Register a function as available through GetProcAddress; the entry point
+/// the generated init code calls.
+pub fn register_export(dll: &str, func: &str, addr: u32) {
+    lock().register_export(dll, func, addr);
 }
 
 #[win32_derive::dllexport]
@@ -110,7 +115,8 @@ pub fn GetModuleHandleA(ctx: &mut Context, lpModuleName: Ptr<u8>) -> HMODULE {
         // A null name asks for the running executable itself.
         return lock().image_base;
     };
-    match module_handle(&name) {
+    let kernel32 = lock();
+    match kernel32.module_handle(&name) {
         Some(handle) => handle,
         None => {
             log::warn!("GetModuleHandleA({name}): not loaded");
@@ -124,10 +130,11 @@ pub fn LoadLibraryA(ctx: &mut Context, lpLibFileName: Ptr<u8>) -> HMODULE {
     let filename = ctx.memory.read_str(lpLibFileName.addr).to_owned();
     // A DLL we implement is already "loaded"; anything else falls through to
     // whatever loader the host installed.
-    if let Some(handle) = module_handle(&filename) {
+    let mut kernel32 = lock();
+    if let Some(handle) = kernel32.module_handle(&filename) {
         return handle;
     }
-    lock().dll_loader.load_library(&filename)
+    kernel32.dll_loader.load_library(&filename)
 }
 
 #[win32_derive::dllexport]
@@ -144,12 +151,14 @@ pub fn GetProcAddress(ctx: &mut Context, hModule: HMODULE, lpProcName: Ptr<u8>) 
     } else {
         ctx.memory.read_str(lpProcName.addr).to_owned()
     };
-    if let Some(module) = module_name(hModule) {
-        if let Some(addr) = proc_address(&module, &name) {
+    let mut kernel32 = lock();
+    if let Some(module) = kernel32.module_name(hModule) {
+        let module = module.to_string();
+        if let Some(addr) = kernel32.proc_address(&module, &name) {
             return addr;
         }
         log::warn!("GetProcAddress({module}, {name}): not implemented, returning null");
         return 0;
     }
-    lock().dll_loader.get_proc_address(hModule, &name)
+    kernel32.dll_loader.get_proc_address(hModule, &name)
 }

--- a/win32/winapi/src/kernel32/dll.rs
+++ b/win32/winapi/src/kernel32/dll.rs
@@ -1,3 +1,5 @@
+use std::sync::Mutex;
+
 use runtime::Context;
 
 use crate::{Ptr, kernel32::lock, stub};
@@ -23,6 +25,70 @@ impl DLLLoader for () {
     }
 }
 
+/// Functions the translated program can look up by name at runtime.
+///
+/// A statically linked import is dispatched by the translator, but a program
+/// that goes through LoadLibrary/GetProcAddress needs an actual address to
+/// call. The translator picks one per function (the same synthetic addresses it
+/// uses for imports, so they resolve through the block table) and registers it
+/// here from the generated init code.
+#[derive(Default)]
+struct Exports {
+    /// (dll, function) -> address, with dll lowercased and without ".dll".
+    functions: Vec<(String, String, u32)>,
+    /// Module handles handed out by LoadLibrary, in registration order.
+    modules: Vec<String>,
+}
+
+static EXPORTS: Mutex<Option<Exports>> = Mutex::new(None);
+
+/// Module handles are synthetic; the value only has to be non-null and
+/// distinguishable.
+const MODULE_HANDLE_BASE: HMODULE = 0xd11_0000;
+
+fn normalize_module_name(name: &str) -> String {
+    let name = name.rsplit(['\\', '/']).next().unwrap();
+    // Lowercase first: stripping ".dll" before folding case misses "Foo.Dll".
+    let name = name.to_ascii_lowercase();
+    name.strip_suffix(".dll").unwrap_or(&name).to_string()
+}
+
+/// Register a function as available through GetProcAddress. Called from
+/// generated init code, once per function the translator reserved an address
+/// for.
+pub fn register_export(dll: &str, func: &str, addr: u32) {
+    let mut exports = EXPORTS.lock().unwrap();
+    let exports = exports.get_or_insert_with(Default::default);
+    let dll = normalize_module_name(dll);
+    if !exports.modules.contains(&dll) {
+        exports.modules.push(dll.clone());
+    }
+    exports.functions.push((dll, func.to_string(), addr));
+}
+
+fn module_handle(name: &str) -> Option<HMODULE> {
+    let exports = EXPORTS.lock().unwrap();
+    let exports = exports.as_ref()?;
+    let name = normalize_module_name(name);
+    let index = exports.modules.iter().position(|module| *module == name)?;
+    Some(MODULE_HANDLE_BASE + index as u32)
+}
+
+fn module_name(handle: HMODULE) -> Option<String> {
+    let index = handle.checked_sub(MODULE_HANDLE_BASE)? as usize;
+    let exports = EXPORTS.lock().unwrap();
+    exports.as_ref()?.modules.get(index).cloned()
+}
+
+fn proc_address(module: &str, func: &str) -> Option<u32> {
+    let exports = EXPORTS.lock().unwrap();
+    exports
+        .as_ref()?
+        .functions
+        .iter()
+        .find_map(|(dll, name, addr)| (dll == module && name == func).then_some(*addr))
+}
+
 #[win32_derive::dllexport]
 pub fn GetModuleFileNameA(
     _ctx: &mut Context,
@@ -37,36 +103,53 @@ pub fn GetModuleFileNameA(
 }
 
 #[win32_derive::dllexport]
-pub fn GetModuleHandleA(_ctx: &mut Context, _lpModuleName: Ptr<u8>) -> HMODULE {
-    stub!(0)
-    /*
-    let state = get_state(sys);
-        let Some(name) = lpModuleName else {
-            return HMODULE::from_raw(state.image_base);
-        };
-        let name = normalize_module_name(name);
-
-        let Some((&hmodule, _)) = state.modules.iter().find(|(_, dll)| dll.name == name) else {
-            sys.set_last_error(ERROR::MOD_NOT_FOUND);
-            return HMODULE::null();
-        };
-
-        hmodule
-        */
+pub fn GetModuleHandleA(ctx: &mut Context, lpModuleName: Ptr<u8>) -> HMODULE {
+    let Some(name) =
+        (lpModuleName.addr != 0).then(|| ctx.memory.read_str(lpModuleName.addr).to_owned())
+    else {
+        // A null name asks for the running executable itself.
+        return lock().image_base;
+    };
+    match module_handle(&name) {
+        Some(handle) => handle,
+        None => {
+            log::warn!("GetModuleHandleA({name}): not loaded");
+            0
+        }
+    }
 }
 
 #[win32_derive::dllexport]
 pub fn LoadLibraryA(ctx: &mut Context, lpLibFileName: Ptr<u8>) -> HMODULE {
-    let filename = ctx.memory.read_str(lpLibFileName.addr);
+    let filename = ctx.memory.read_str(lpLibFileName.addr).to_owned();
+    // A DLL we implement is already "loaded"; anything else falls through to
+    // whatever loader the host installed.
+    if let Some(handle) = module_handle(&filename) {
+        return handle;
+    }
     lock().dll_loader.load_library(&filename)
 }
 
 #[win32_derive::dllexport]
+pub fn FreeLibrary(_ctx: &mut Context, _hLibModule: HMODULE) -> bool {
+    // Our modules are always resident.
+    true
+}
+
+#[win32_derive::dllexport]
 pub fn GetProcAddress(ctx: &mut Context, hModule: HMODULE, lpProcName: Ptr<u8>) -> u32 {
+    // A name below 0x1000 is really an ordinal, per the API's convention.
     let name = if lpProcName.addr < 0x1000 {
         format!("ordinal{}", lpProcName.addr)
     } else {
         ctx.memory.read_str(lpProcName.addr).to_owned()
     };
+    if let Some(module) = module_name(hModule) {
+        if let Some(addr) = proc_address(&module, &name) {
+            return addr;
+        }
+        log::warn!("GetProcAddress({module}, {name}): not implemented, returning null");
+        return 0;
+    }
     lock().dll_loader.get_proc_address(hModule, &name)
 }

--- a/win32/winapi/src/kernel32/process.rs
+++ b/win32/winapi/src/kernel32/process.rs
@@ -112,7 +112,9 @@ impl kernel32::State {
         let (peb, _buf) = PEB::mut_from_prefix(buf).unwrap();
         peb.ProcessParameters = (params as *const _ as usize - origin) as u32;
 
-        let heap_size = 4 << 20;
+        // Games of this era load whole asset archives into the process heap,
+        // so give it room; the address space is ours to spend.
+        let heap_size = 64 << 20;
         let heap_addr = self.mappings.alloc("process heap".into(), heap_size);
         let process_heap = Heap::new(heap_addr, heap_size);
         peb.ProcessHeap = process_heap.addr;

--- a/win32/winapi/src/kernel32/state.rs
+++ b/win32/winapi/src/kernel32/state.rs
@@ -20,6 +20,7 @@ pub struct State {
     pub next_thread_id: u32,
     pub next_tls_index: u32,
     pub dll_loader: Box<dyn kernel32::DLLLoader>,
+    pub exports: kernel32::Exports,
     pub objects: Handles<Object>,
 }
 
@@ -38,6 +39,7 @@ pub fn init_state(image_base: u32, resources: std::ops::Range<u32>) {
         next_thread_id: 2,
         next_tls_index: 0,
         dll_loader: Box::new(()),
+        exports: Default::default(),
         objects: Handles::new(0x1000),
     });
 }

--- a/win32/winapi/src/kernel32/time.rs
+++ b/win32/winapi/src/kernel32/time.rs
@@ -11,10 +11,8 @@ pub fn Sleep(_ctx: &mut Context, dwMilliseconds: u32) {
 }
 
 #[win32_derive::dllexport]
-pub fn GetTimeZoneInformation(
-    ctx: &mut Context,
-    lpTimeZoneInformation: crate::Ptr<u8>,
-) -> u32 /* TIME_ZONE_ID */ {
+pub fn GetTimeZoneInformation(ctx: &mut Context, lpTimeZoneInformation: crate::Ptr<u8>) -> u32 /* TIME_ZONE_ID */
+{
     // TIME_ZONE_INFORMATION is 172 bytes; report UTC by zeroing it.
     ctx.memory[lpTimeZoneInformation.addr..][..172].fill(0);
     0 // TIME_ZONE_ID_UNKNOWN

--- a/win32/winapi/src/lib.rs
+++ b/win32/winapi/src/lib.rs
@@ -24,6 +24,20 @@ pub mod trace;
 pub mod user32;
 pub mod winmm;
 
+/// Functions a program may resolve at runtime with LoadLibrary/GetProcAddress
+/// instead of importing statically. The translator reserves a callable address
+/// for each of these, so a call through the returned pointer lands somewhere.
+///
+/// Statically imported functions need no entry here; only add a name when a
+/// program is seen looking it up by hand.
+pub const DYNAMIC_EXPORTS: &[(&str, &[&str])] = &[
+    // The Microsoft C runtime loads user32 on demand to report fatal errors.
+    (
+        "user32",
+        &["MessageBoxA", "GetActiveWindow", "GetLastActivePopup"],
+    ),
+];
+
 pub use dllexport::{ABIReturn, FromABIParam};
 pub use handle::{HANDLE, Handles};
 pub use point::POINT;

--- a/win32/winapi/src/winmm/mmio.rs
+++ b/win32/winapi/src/winmm/mmio.rs
@@ -16,12 +16,7 @@ pub fn mciSendCommandA(
 }
 
 #[win32_derive::dllexport]
-pub fn mmioOpenA(
-    _ctx: &mut Context,
-    _szFilename: u32,
-    _lpmmioinfo: u32,
-    _dwOpenFlags: u32,
-) -> u32 {
+pub fn mmioOpenA(_ctx: &mut Context, _szFilename: u32, _lpmmioinfo: u32, _dwOpenFlags: u32) -> u32 {
     todo!("mmioOpenA")
 }
 


### PR DESCRIPTION


Part 8 of 15, splitting up #1. Applies to main on its own and compiles.
