### PR TITLE
13/15 ddraw: colorkey, palettes, pixel formats

### DIFF
--- a/win32/winapi/src/ddraw/ddraw.rs
+++ b/win32/winapi/src/ddraw/ddraw.rs
@@ -51,11 +51,18 @@ impl DirectDraw {
         };
         drop(window);
 
-        let bytes_per_pixel = if is_primary {
-            self.bytes_per_pixel
+        // An offscreen surface takes the display mode's format unless the app
+        // asks for a specific one, which is what lets a palettized game blit
+        // between its buffers without conversion.
+        let bytes_per_pixel = if desc.dwFlags.contains(DDSD::PIXELFORMAT) {
+            let bits = desc.ddpfPixelFormat.dwRGBBitCount;
+            if bits == 0 {
+                self.bytes_per_pixel
+            } else {
+                bits.div_ceil(8)
+            }
         } else {
-            log::warn!("creating surface assuming 32bpp");
-            4
+            self.bytes_per_pixel
         };
 
         let surface = self.create_one_surface(
@@ -67,6 +74,19 @@ impl DirectDraw {
                 bytes_per_pixel,
             },
         );
+
+        if desc.dwFlags.contains(DDSD::CKSRCBLT) {
+            surface.borrow_mut().src_color_key = Some(ColorKey {
+                low: desc.ddckCKSrcBlt.dwColorSpaceLowValue,
+                high: desc.ddckCKSrcBlt.dwColorSpaceHighValue,
+            });
+        }
+        if desc.dwFlags.contains(DDSD::CKDESTBLT) {
+            surface.borrow_mut().dst_color_key = Some(ColorKey {
+                low: desc.ddckCKDestBlt.dwColorSpaceLowValue,
+                high: desc.ddckCKDestBlt.dwColorSpaceHighValue,
+            });
+        }
 
         if let Some(count) = desc.back_buffer_count() {
             assert_eq!(count, 1);
@@ -100,6 +120,7 @@ impl DirectDraw {
 
         let surf = Rc::new(RefCell::new(Surface {
             addr,
+            refs: 1,
             width: params.width,
             height: params.height,
             bytes_per_pixel: params.bytes_per_pixel,
@@ -108,6 +129,8 @@ impl DirectDraw {
             attached: Default::default(),
             pixels: None,
             palette: None,
+            src_color_key: None,
+            dst_color_key: None,
         }));
         // TODO: move surf to ddraw
         state().surf.borrow_mut().insert(addr, surf.clone());
@@ -120,8 +143,25 @@ pub enum Target {
     Texture(host::Surface),
 }
 
+/// A DDCOLORKEY: the inclusive range of pixel values a blit treats as
+/// transparent.
+#[derive(Copy, Clone, Debug)]
+pub struct ColorKey {
+    pub low: u32,
+    pub high: u32,
+}
+
+impl ColorKey {
+    pub fn matches(&self, pixel: u32) -> bool {
+        (self.low..=self.high).contains(&pixel)
+    }
+}
+
 pub struct Surface {
     pub addr: u32,
+    /// COM reference count. An app that balances AddRef/Release expects the
+    /// surface to outlive the matching Release, so this has to be real.
+    pub refs: u32,
     pub width: u32,
     pub height: u32,
     pub bytes_per_pixel: u32,
@@ -138,6 +178,13 @@ pub struct Surface {
     pub pixels: Option<u32>,
 
     pub palette: Option<Rc<RefCell<Palette>>>,
+
+    /// Pixel values that read as transparent when this surface is the source
+    /// of a blit — how sprites get their transparent background.
+    pub src_color_key: Option<ColorKey>,
+    /// Pixel values that may be overwritten when this surface is the
+    /// destination of a blit.
+    pub dst_color_key: Option<ColorKey>,
 }
 
 impl Surface {
@@ -156,44 +203,98 @@ impl Surface {
     }
 
     pub fn unlock(&mut self, mem: &mut Memory) {
-        self.update_texture(mem, &None);
+        match self.target {
+            // Writes to the primary surface go straight to the screen.
+            Target::Window(_) => self.present(mem),
+            Target::Texture(_) => self.update_texture(mem, &None),
+        }
+    }
+
+    /// Convert this surface's pixels to the RGBA the host wants, using
+    /// `palette` for palettized formats. Borrows the pixels directly when they
+    /// are already RGBA. Returns None when there is nothing to show, e.g. an
+    /// 8-bit surface with no palette attached yet.
+    fn to_rgba<'a>(
+        &self,
+        mem: &'a Memory,
+        palette: &Option<Rc<RefCell<Palette>>>,
+    ) -> Option<std::borrow::Cow<'a, [u8]>> {
+        let addr = self.pixels?;
+        let size = self.width * self.height * self.bytes_per_pixel;
+        let pixels = &mem[addr..][..size as usize];
+        Some(match self.bytes_per_pixel {
+            1 => {
+                let palette = palette.as_ref()?;
+                let entries = &palette.borrow().entries;
+                let mut buf = Vec::with_capacity(pixels.len() * 4);
+                for &p in pixels {
+                    let entry = &entries[p as usize];
+                    // ABGR8888 layout: R,G,B,A in byte order.
+                    buf.push(entry.peRed);
+                    buf.push(entry.peGreen);
+                    buf.push(entry.peBlue);
+                    buf.push(0);
+                }
+                buf.into()
+            }
+            2 => {
+                // RGB565, the standard 16-bit display format.
+                let mut buf = Vec::with_capacity(pixels.len() * 2);
+                for pixel in pixels.chunks_exact(2) {
+                    let pixel = u16::from_le_bytes([pixel[0], pixel[1]]);
+                    let (r, g, b) = (pixel >> 11, (pixel >> 5) & 0x3f, pixel & 0x1f);
+                    // Replicate the high bits into the low ones so full-scale
+                    // values stay full-scale.
+                    buf.push((r << 3 | r >> 2) as u8);
+                    buf.push((g << 2 | g >> 4) as u8);
+                    buf.push((b << 3 | b >> 2) as u8);
+                    buf.push(0);
+                }
+                buf.into()
+            }
+            4 => pixels.into(),
+            bpp => {
+                log::warn!("unsupported surface format: {bpp} bytes per pixel");
+                return None;
+            }
+        })
     }
 
     // App can write pixels to back buffer but attach palette to front buffer,
     // so take palette as an argument.
     fn update_texture(&mut self, mem: &mut Memory, palette: &Option<Rc<RefCell<Palette>>>) {
-        let Some(addr) = self.pixels else {
+        let Some(pixels) = self.to_rgba(mem, palette) else {
             return;
         };
-        let size = self.width * self.height * self.bytes_per_pixel;
-        let pixels = &mem[addr..][..size as usize];
-        let mut buf = vec![];
-        let pixels32 = match self.bytes_per_pixel {
-            1 => {
-                let Some(palette) = palette.as_ref() else {
-                    // e.g. unlock on a back buffer with no palette attached
-                    return;
-                };
-                let palette = palette.borrow();
-                let entries = &palette.entries;
-                for &p in pixels {
-                    let entry = &entries[p as usize];
-                    buf.push(entry.peBlue);
-                    buf.push(entry.peGreen);
-                    buf.push(entry.peRed);
-                    buf.push(0);
-                }
-                buf.as_slice()
-            }
-            4 => pixels,
-            _ => todo!(),
-        };
+        let width = self.width;
         match &mut self.target {
             Target::Window(_) => unreachable!(),
             Target::Texture(texture) => {
-                texture.set_pixels(pixels32, self.width * 4);
+                texture.set_pixels(&pixels, width * 4);
             }
         }
+    }
+
+    /// Present this surface's own pixel buffer to the window it targets, used
+    /// when an app draws directly to the primary surface (via Lock or Blt)
+    /// instead of flipping. No-op for non-primary surfaces.
+    pub fn present(&mut self, mem: &mut Memory) {
+        let Target::Window(window) = &self.target else {
+            return;
+        };
+        // We have no texture of our own; borrow the back buffer's.
+        let Some(back) = self.attached.clone() else {
+            return;
+        };
+        let Some(pixels) = self.to_rgba(mem, &self.palette) else {
+            return;
+        };
+        let mut back = back.borrow_mut();
+        let Target::Texture(texture) = &mut back.target else {
+            return;
+        };
+        texture.set_pixels(&pixels, self.width * 4);
+        window.borrow_mut().host.render(texture);
     }
 
     pub fn flip(&mut self, mem: &mut Memory) {

--- a/win32/winapi/src/ddraw/ddraw.rs
+++ b/win32/winapi/src/ddraw/ddraw.rs
@@ -4,6 +4,7 @@ use runtime::*;
 
 use super::types::*;
 use crate::{
+    RECT,
     ddraw::{GUID, ddraw1, ddraw7, state},
     kernel32,
     user32::{self, HWND},
@@ -371,5 +372,273 @@ pub fn DirectDrawCreateEx(
     });
 
     ctx.memory.write(lplpDD, addr);
+    DD::OK
+}
+
+pub fn read_rect(ctx: &Context, addr: u32) -> Option<RECT> {
+    if addr == 0 {
+        None
+    } else {
+        crate::Ptr::<RECT>::new(addr).read(&ctx.memory)
+    }
+}
+
+/// Copy a rect between two surfaces (which may be the same one; the copy
+/// stages through a temporary buffer).
+///
+/// With a `color_key`, source pixels inside its range are left alone in the
+/// destination, which is how sprites get transparent backgrounds.
+pub fn blit_copy(
+    ctx: &mut Context,
+    dst_ptr: u32,
+    dst_rect: Option<RECT>,
+    src_ptr: u32,
+    src_rect: Option<RECT>,
+    color_key: Option<ColorKey>,
+) {
+    let src_rc = state().surf.borrow_mut().get(&src_ptr).unwrap().clone();
+    let dst_rc = state().surf.borrow_mut().get(&dst_ptr).unwrap().clone();
+
+    let (rows, row_bytes, row_count, bpp) = {
+        let mut src = src_rc.borrow_mut();
+        let addr = src.lock(&mut ctx.memory);
+        let bpp = src.bytes_per_pixel;
+        let stride = src.width * bpp;
+        let rect = src_rect
+            .unwrap_or_else(|| RECT::from_size(src.width, src.height))
+            .clip_to_size(src.width, src.height);
+        let row_bytes = ((rect.right - rect.left).max(0) as u32 * bpp) as usize;
+        let row_count = (rect.bottom - rect.top).max(0) as usize;
+        let mut rows = Vec::with_capacity(row_bytes * row_count);
+        for y in rect.top..rect.bottom {
+            let start = addr + y as u32 * stride + rect.left as u32 * bpp;
+            rows.extend_from_slice(&ctx.memory[start..][..row_bytes]);
+        }
+        (rows, row_bytes, row_count, bpp)
+    };
+
+    let mut dst = dst_rc.borrow_mut();
+    if dst.bytes_per_pixel != bpp {
+        log::warn!("blit between different pixel formats");
+        return;
+    }
+    let addr = dst.lock(&mut ctx.memory);
+    let stride = dst.width * bpp;
+    let want = dst_rect.unwrap_or_else(|| RECT::from_size(dst.width, dst.height));
+    let rect = want.clip_to_size(dst.width, dst.height);
+    // Whatever the clip took off the top and left has to come off the
+    // source as well, otherwise the image slides instead of being cropped.
+    let skip_x = (rect.left - want.left).max(0) as usize * bpp as usize;
+    let skip_y = (rect.top - want.top).max(0) as usize;
+    // No stretching: copy 1:1, clipped to both rects.
+    let copy_bytes = row_bytes
+        .saturating_sub(skip_x)
+        .min(((rect.right - rect.left).max(0) as u32 * bpp) as usize);
+    let copy_rows = row_count
+        .saturating_sub(skip_y)
+        .min((rect.bottom - rect.top).max(0) as usize);
+    for i in 0..copy_rows {
+        let dst_start = addr + (rect.top + i as i32) as u32 * stride + rect.left as u32 * bpp;
+        let row = &rows[(i + skip_y) * row_bytes + skip_x..][..copy_bytes];
+        match color_key {
+            None => ctx.memory[dst_start..][..copy_bytes].copy_from_slice(row),
+            Some(key) => {
+                for (x, pixel) in row.chunks_exact(bpp as usize).enumerate() {
+                    let value = match bpp {
+                        1 => pixel[0] as u32,
+                        2 => u16::from_le_bytes(pixel.try_into().unwrap()) as u32,
+                        4 => u32::from_le_bytes(pixel.try_into().unwrap()),
+                        _ => {
+                            log::warn!("colorkey blit at {bpp} bytes per pixel");
+                            return;
+                        }
+                    };
+                    if key.matches(value) {
+                        continue;
+                    }
+                    let at = dst_start + x as u32 * bpp;
+                    ctx.memory[at..][..bpp as usize].copy_from_slice(pixel);
+                }
+            }
+        }
+    }
+    dst.present(&mut ctx.memory);
+}
+
+pub fn surface_src_color_key(surface: u32) -> Option<ColorKey> {
+    let surfaces = state().surf.borrow();
+    let key = surfaces.get(&surface)?.borrow().src_color_key;
+    if key.is_none() {
+        log::warn!("blit asked for a source color key, but none is set");
+    }
+    key
+}
+
+pub fn blt(
+    ctx: &mut Context,
+    this: u32,
+    lpDstRect: u32,
+    lpDDSrcSurface: u32,
+    lpSrcRect: u32,
+    dwFlags: u32,
+    lpDDBLTFX: u32,
+) -> DD {
+    const DDBLT_COLORFILL: u32 = 0x0400;
+    const DDBLT_KEYSRC: u32 = 0x8000;
+    const DDBLT_KEYSRCOVERRIDE: u32 = 0x0001_0000;
+    const DDBLT_WAIT: u32 = 0x0100_0000;
+    const KNOWN: u32 = DDBLT_COLORFILL | DDBLT_KEYSRC | DDBLT_KEYSRCOVERRIDE | DDBLT_WAIT;
+    if dwFlags & !KNOWN != 0 {
+        log::warn!("Blt: ignoring flags {:#x}", dwFlags & !KNOWN);
+    }
+
+    let dst_rect = read_rect(ctx, lpDstRect);
+    if dwFlags & DDBLT_COLORFILL != 0 {
+        // DDBLTFX.dwFillColor is at offset 80.
+        let color = ctx.memory.read::<u32>(lpDDBLTFX + 80);
+        let dst_rc = state().surf.borrow_mut().get(&this).unwrap().clone();
+        let mut dst = dst_rc.borrow_mut();
+        let bpp = dst.bytes_per_pixel;
+        let rect = dst_rect
+            .unwrap_or_else(|| RECT::from_size(dst.width, dst.height))
+            .clip_to_size(dst.width, dst.height);
+        let addr = dst.lock(&mut ctx.memory);
+        let stride = dst.width * bpp;
+        for y in rect.top..rect.bottom {
+            let start = addr + y as u32 * stride + rect.left as u32 * bpp;
+            let width_bytes = ((rect.right - rect.left).max(0) as u32 * bpp) as usize;
+            match bpp {
+                1 => ctx.memory[start..][..width_bytes].fill(color as u8),
+                4 => {
+                    for x in 0..(rect.right - rect.left).max(0) as u32 {
+                        ctx.memory.write::<u32>(start + x * 4, color);
+                    }
+                }
+                _ => todo!("Blt colorfill bpp {bpp}"),
+            }
+        }
+        dst.present(&mut ctx.memory);
+        return DD::OK;
+    }
+
+    let color_key = if dwFlags & DDBLT_KEYSRCOVERRIDE != 0 {
+        // DDBLTFX.ddckSrcColorkey, past the z-buffer and alpha fields.
+        Some(ColorKey {
+            low: ctx.memory.read::<u32>(lpDDBLTFX + 92),
+            high: ctx.memory.read::<u32>(lpDDBLTFX + 96),
+        })
+    } else if dwFlags & DDBLT_KEYSRC != 0 {
+        surface_src_color_key(lpDDSrcSurface)
+    } else {
+        None
+    };
+
+    let src_rect = read_rect(ctx, lpSrcRect);
+    blit_copy(ctx, this, dst_rect, lpDDSrcSurface, src_rect, color_key);
+    DD::OK
+}
+
+pub fn blt_fast(
+    ctx: &mut Context,
+    this: u32,
+    dwX: u32,
+    dwY: u32,
+    lpDDSrcSurface: u32,
+    lpSrcRect: u32,
+    dwTrans: u32,
+) -> DD {
+    const DDBLTFAST_SRCCOLORKEY: u32 = 0x0001;
+    const DDBLTFAST_DESTCOLORKEY: u32 = 0x0002;
+    const DDBLTFAST_WAIT: u32 = 0x0010;
+    const KNOWN: u32 = DDBLTFAST_SRCCOLORKEY | DDBLTFAST_DESTCOLORKEY | DDBLTFAST_WAIT;
+    if dwTrans & !KNOWN != 0 {
+        log::warn!("BltFast: ignoring flags {:#x}", dwTrans & !KNOWN);
+    }
+    if dwTrans & DDBLTFAST_DESTCOLORKEY != 0 {
+        // Would need to test the destination pixel rather than the source;
+        // no caller has needed it.
+        log::warn!("BltFast: destination color key not supported");
+    }
+    let color_key = if dwTrans & DDBLTFAST_SRCCOLORKEY != 0 {
+        surface_src_color_key(lpDDSrcSurface)
+    } else {
+        None
+    };
+
+    let src_rect = read_rect(ctx, lpSrcRect);
+    let (w, h) = match &src_rect {
+        Some(r) => ((r.right - r.left).max(0), (r.bottom - r.top).max(0)),
+        None => {
+            let src = state()
+                .surf
+                .borrow_mut()
+                .get(&lpDDSrcSurface)
+                .unwrap()
+                .clone();
+            let src = src.borrow();
+            (src.width as i32, src.height as i32)
+        }
+    };
+    let dst_rect = RECT {
+        left: dwX as i32,
+        top: dwY as i32,
+        right: dwX as i32 + w,
+        bottom: dwY as i32 + h,
+    };
+    blit_copy(
+        ctx,
+        this,
+        Some(dst_rect),
+        lpDDSrcSurface,
+        src_rect,
+        color_key,
+    );
+    DD::OK
+}
+
+pub fn set_color_key(ctx: &mut Context, this: u32, dwFlags: u32, lpDDColorKey: u32) -> DD {
+    let key = if lpDDColorKey == 0 {
+        None
+    } else {
+        // DDCOLORKEY: dwColorSpaceLowValue, dwColorSpaceHighValue.
+        Some(ColorKey {
+            low: ctx.memory.read::<u32>(lpDDColorKey),
+            high: ctx.memory.read::<u32>(lpDDColorKey + 4),
+        })
+    };
+    let surfaces = state().surf.borrow();
+    let Some(surface) = surfaces.get(&this) else {
+        return DD::ERR_GENERIC;
+    };
+    let mut surface = surface.borrow_mut();
+    if dwFlags & (DDCKEY_SRCOVERLAY | DDCKEY_DESTOVERLAY) != 0 {
+        log::warn!("SetColorKey: overlays are not supported");
+    }
+    if dwFlags & DDCKEY_DESTBLT != 0 {
+        surface.dst_color_key = key;
+    } else {
+        surface.src_color_key = key;
+    }
+    DD::OK
+}
+
+pub fn get_color_key(ctx: &mut Context, this: u32, dwFlags: u32, lpDDColorKey: u32) -> DD {
+    let key = {
+        let surfaces = state().surf.borrow();
+        let Some(surface) = surfaces.get(&this) else {
+            return DD::ERR_GENERIC;
+        };
+        let surface = surface.borrow();
+        if dwFlags & DDCKEY_DESTBLT != 0 {
+            surface.dst_color_key
+        } else {
+            surface.src_color_key
+        }
+    };
+    let Some(key) = key else {
+        return DD::ERR_NOCOLORKEY;
+    };
+    ctx.memory.write::<u32>(lpDDColorKey, key.low);
+    ctx.memory.write::<u32>(lpDDColorKey + 4, key.high);
     DD::OK
 }

--- a/win32/winapi/src/ddraw/ddraw1.rs
+++ b/win32/winapi/src/ddraw/ddraw1.rs
@@ -4,7 +4,8 @@ use runtime::Context;
 use zerocopy::{FromBytes, IntoBytes};
 
 use crate::{
-    ddraw::{DD, Palette, get_pixel_format, state, types::*},
+    RECT,
+    ddraw::{ColorKey, DD, GUID, Palette, get_pixel_format, state, types::*},
     heap::Heap,
     kernel32, stub,
     user32::HWND,
@@ -40,18 +41,22 @@ pub mod IDirectDraw {
     ];
 
     #[win32_derive::dllexport]
-    pub fn QueryInterface(_ctx: &mut Context, _this: u32, _riid: u32, _ppvObject: u32) -> DD {
-        todo!()
+    pub fn QueryInterface(ctx: &mut Context, _this: u32, riid: u32, _ppvObject: u32) -> DD {
+        let iid = crate::Ptr::<GUID>::new(riid).read(&ctx.memory);
+        log::warn!("IDirectDraw::QueryInterface({iid:?}): not supported");
+        DD::E_NOINTERFACE
     }
 
     #[win32_derive::dllexport]
     pub fn AddRef(_ctx: &mut Context, _this: u32) -> u32 {
-        todo!()
+        // We don't reference count; the single DirectDraw object lives as long
+        // as the process.
+        1
     }
 
     #[win32_derive::dllexport]
     pub fn Release(_ctx: &mut Context, _this: u32) -> u32 {
-        todo!()
+        0
     }
 
     #[win32_derive::dllexport]
@@ -121,8 +126,69 @@ pub mod IDirectDraw {
     }
 
     #[win32_derive::dllexport]
-    pub fn EnumDisplayModes(_ctx: &mut Context, _this: u32) -> DD {
-        todo!()
+    pub fn EnumDisplayModes(
+        ctx: &mut Context,
+        _this: u32,
+        _dwFlags: u32,
+        lpSurfaceDesc: u32,
+        lpContext: u32,
+        lpEnumCallback: u32,
+    ) -> DD {
+        if lpSurfaceDesc != 0 {
+            todo!("EnumDisplayModes with a filter desc");
+        }
+
+        // Report the standard display modes; games match these against their
+        // internal mode tables by width/height/bit count.
+        const RESOLUTIONS: &[(u32, u32)] = &[(640, 480), (800, 600), (1024, 768)];
+        // Only depths the surface code can actually convert to rgba.
+        const BIT_DEPTHS: &[u32] = &[8, 16, 32];
+
+        for &(width, height) in RESOLUTIONS {
+            for &bpp in BIT_DEPTHS {
+                let mut desc = DDSURFACEDESC::default();
+                desc.dwSize = std::mem::size_of::<DDSURFACEDESC>() as u32;
+                desc.dwFlags = DDSD::WIDTH | DDSD::HEIGHT | DDSD::PIXELFORMAT | DDSD::PITCH;
+                desc.dwWidth = width;
+                desc.dwHeight = height;
+                desc.lPitch_dwLinearSize = width * bpp.div_ceil(8);
+
+                // DDPF_RGB = 0x40, DDPF_PALETTEINDEXED8 = 0x20.
+                let (flags, r, g, b) = match bpp {
+                    8 => (0x40 | 0x20, 0, 0, 0),
+                    16 => (0x40, 0xF800, 0x07E0, 0x001F), // 5-6-5
+                    _ => (0x40, 0xFF0000, 0x00FF00, 0x0000FF), // 24/32
+                };
+                desc.ddpfPixelFormat = DDPIXELFORMAT {
+                    dwSize: std::mem::size_of::<DDPIXELFORMAT>() as u32,
+                    dwFlags: flags,
+                    dwFourCC: 0,
+                    dwRGBBitCount: bpp,
+                    dwRBitMask: r,
+                    dwGBitMask: g,
+                    dwBBitMask: b,
+                    dwRGBAlphaBitMask: 0,
+                };
+
+                let desc_addr = kernel32::lock()
+                    .process_heap
+                    .alloc(&mut ctx.memory, desc.dwSize);
+                ctx.memory.write(desc_addr, desc);
+                let callback = ctx.indirect(lpEnumCallback);
+                ctx.call32_x86(callback, vec![desc_addr, lpContext]);
+                let ret = ctx.cpu.regs.eax;
+                kernel32::lock()
+                    .process_heap
+                    .free(&mut ctx.memory, desc_addr);
+
+                // DDENUMRET_CANCEL (0) means stop enumerating.
+                if ret == 0 {
+                    return DD::OK;
+                }
+            }
+        }
+
+        DD::OK
     }
 
     #[win32_derive::dllexport]
@@ -171,8 +237,15 @@ pub mod IDirectDraw {
     }
 
     #[win32_derive::dllexport]
-    pub fn Initialize(_ctx: &mut Context, _this: u32) -> DD {
-        todo!()
+    pub fn Initialize(
+        _ctx: &mut Context,
+        _this: u32,
+        _lpDD: u32,
+        _dwFlags: u32,
+        _lpDDColorTable: u32,
+    ) -> DD {
+        // Nothing to do: the object is fully constructed when it's created.
+        DD::OK
     }
 
     #[win32_derive::dllexport]
@@ -201,8 +274,8 @@ pub mod IDirectDraw {
     }
 
     #[win32_derive::dllexport]
-    pub fn WaitForVerticalBlank(_ctx: &mut Context, _this: u32) -> DD {
-        todo!()
+    pub fn WaitForVerticalBlank(_ctx: &mut Context, _this: u32, _dwFlags: u32, _hEvent: u32) -> DD {
+        DD::OK // pretend the vblank already happened
     }
 
     pub static mut VTABLE: u32 = 0;
@@ -257,18 +330,48 @@ pub mod IDirectDrawSurface {
     ];
 
     #[win32_derive::dllexport]
-    pub fn QueryInterface(_ctx: &mut Context, _this: u32) -> DD {
-        todo!()
+    pub fn QueryInterface(ctx: &mut Context, _this: u32, riid: u32, _ppvObject: u32) -> DD {
+        let iid = crate::Ptr::<GUID>::new(riid).read(&ctx.memory);
+        log::warn!("IDirectDrawSurface::QueryInterface({iid:?}): not supported");
+        DD::E_NOINTERFACE
     }
 
     #[win32_derive::dllexport]
-    pub fn AddRef(_ctx: &mut Context, _this: u32) -> u32 {
-        todo!()
+    pub fn AddRef(_ctx: &mut Context, this: u32) -> u32 {
+        match state().surf.borrow_mut().get(&this) {
+            Some(surface) => {
+                let mut surface = surface.borrow_mut();
+                surface.refs += 1;
+                surface.refs
+            }
+            None => 0,
+        }
     }
 
     #[win32_derive::dllexport]
-    pub fn Release(_ctx: &mut Context, _this: u32) -> u32 {
-        todo!()
+    pub fn Release(ctx: &mut Context, this: u32) -> u32 {
+        let surfaces = state().surf.borrow_mut();
+        let Some(surface) = surfaces.get(&this) else {
+            return 0;
+        };
+        let remaining = {
+            let mut surface = surface.borrow_mut();
+            surface.refs = surface.refs.saturating_sub(1);
+            surface.refs
+        };
+        drop(surfaces);
+        if remaining > 0 {
+            return remaining;
+        }
+        let Some(surface) = state().surf.borrow_mut().remove(&this) else {
+            return 0;
+        };
+        // Games recreate surfaces when changing screens, so returning the
+        // pixels keeps the heap from growing without bound.
+        if let Some(pixels) = surface.borrow_mut().pixels.take() {
+            kernel32::lock().process_heap.free(&mut ctx.memory, pixels);
+        }
+        0
     }
 
     #[win32_derive::dllexport]
@@ -281,9 +384,168 @@ pub mod IDirectDrawSurface {
         todo!()
     }
 
+    fn read_rect(ctx: &Context, addr: u32) -> Option<RECT> {
+        if addr == 0 {
+            None
+        } else {
+            crate::Ptr::<RECT>::new(addr).read(&ctx.memory)
+        }
+    }
+
+    /// Copy a rect between two surfaces (which may be the same one; the copy
+    /// stages through a temporary buffer).
+    ///
+    /// With a `color_key`, source pixels inside its range are left alone in the
+    /// destination, which is how sprites get transparent backgrounds.
+    pub fn blit_copy(
+        ctx: &mut Context,
+        dst_ptr: u32,
+        dst_rect: Option<RECT>,
+        src_ptr: u32,
+        src_rect: Option<RECT>,
+        color_key: Option<ColorKey>,
+    ) {
+        let src_rc = state().surf.borrow_mut().get(&src_ptr).unwrap().clone();
+        let dst_rc = state().surf.borrow_mut().get(&dst_ptr).unwrap().clone();
+
+        let (rows, row_bytes, row_count, bpp) = {
+            let mut src = src_rc.borrow_mut();
+            let addr = src.lock(&mut ctx.memory);
+            let bpp = src.bytes_per_pixel;
+            let stride = src.width * bpp;
+            let rect = src_rect
+                .unwrap_or_else(|| RECT::from_size(src.width, src.height))
+                .clip_to_size(src.width, src.height);
+            let row_bytes = ((rect.right - rect.left).max(0) as u32 * bpp) as usize;
+            let row_count = (rect.bottom - rect.top).max(0) as usize;
+            let mut rows = Vec::with_capacity(row_bytes * row_count);
+            for y in rect.top..rect.bottom {
+                let start = addr + y as u32 * stride + rect.left as u32 * bpp;
+                rows.extend_from_slice(&ctx.memory[start..][..row_bytes]);
+            }
+            (rows, row_bytes, row_count, bpp)
+        };
+
+        let mut dst = dst_rc.borrow_mut();
+        if dst.bytes_per_pixel != bpp {
+            log::warn!("blit between different pixel formats");
+            return;
+        }
+        let addr = dst.lock(&mut ctx.memory);
+        let stride = dst.width * bpp;
+        let want = dst_rect.unwrap_or_else(|| RECT::from_size(dst.width, dst.height));
+        let rect = want.clip_to_size(dst.width, dst.height);
+        // Whatever the clip took off the top and left has to come off the
+        // source as well, otherwise the image slides instead of being cropped.
+        let skip_x = (rect.left - want.left).max(0) as usize * bpp as usize;
+        let skip_y = (rect.top - want.top).max(0) as usize;
+        // No stretching: copy 1:1, clipped to both rects.
+        let copy_bytes = row_bytes
+            .saturating_sub(skip_x)
+            .min(((rect.right - rect.left).max(0) as u32 * bpp) as usize);
+        let copy_rows = row_count
+            .saturating_sub(skip_y)
+            .min((rect.bottom - rect.top).max(0) as usize);
+        for i in 0..copy_rows {
+            let dst_start = addr + (rect.top + i as i32) as u32 * stride + rect.left as u32 * bpp;
+            let row = &rows[(i + skip_y) * row_bytes + skip_x..][..copy_bytes];
+            match color_key {
+                None => ctx.memory[dst_start..][..copy_bytes].copy_from_slice(row),
+                Some(key) => {
+                    for (x, pixel) in row.chunks_exact(bpp as usize).enumerate() {
+                        let value = match bpp {
+                            1 => pixel[0] as u32,
+                            2 => u16::from_le_bytes(pixel.try_into().unwrap()) as u32,
+                            4 => u32::from_le_bytes(pixel.try_into().unwrap()),
+                            _ => {
+                                log::warn!("colorkey blit at {bpp} bytes per pixel");
+                                return;
+                            }
+                        };
+                        if key.matches(value) {
+                            continue;
+                        }
+                        let at = dst_start + x as u32 * bpp;
+                        ctx.memory[at..][..bpp as usize].copy_from_slice(pixel);
+                    }
+                }
+            }
+        }
+        dst.present(&mut ctx.memory);
+    }
+
     #[win32_derive::dllexport]
-    pub fn Blt(_ctx: &mut Context, _this: u32) -> DD {
-        todo!()
+    pub fn Blt(
+        ctx: &mut Context,
+        this: u32,
+        lpDstRect: u32,
+        lpDDSrcSurface: u32,
+        lpSrcRect: u32,
+        dwFlags: u32,
+        lpDDBLTFX: u32,
+    ) -> DD {
+        const DDBLT_COLORFILL: u32 = 0x0400;
+        const DDBLT_KEYSRC: u32 = 0x8000;
+        const DDBLT_KEYSRCOVERRIDE: u32 = 0x0001_0000;
+        const DDBLT_WAIT: u32 = 0x0100_0000;
+        const KNOWN: u32 = DDBLT_COLORFILL | DDBLT_KEYSRC | DDBLT_KEYSRCOVERRIDE | DDBLT_WAIT;
+        if dwFlags & !KNOWN != 0 {
+            log::warn!("Blt: ignoring flags {:#x}", dwFlags & !KNOWN);
+        }
+
+        let dst_rect = read_rect(ctx, lpDstRect);
+        if dwFlags & DDBLT_COLORFILL != 0 {
+            // DDBLTFX.dwFillColor is at offset 80.
+            let color = ctx.memory.read::<u32>(lpDDBLTFX + 80);
+            let dst_rc = state().surf.borrow_mut().get(&this).unwrap().clone();
+            let mut dst = dst_rc.borrow_mut();
+            let bpp = dst.bytes_per_pixel;
+            let rect = dst_rect
+                .unwrap_or_else(|| RECT::from_size(dst.width, dst.height))
+                .clip_to_size(dst.width, dst.height);
+            let addr = dst.lock(&mut ctx.memory);
+            let stride = dst.width * bpp;
+            for y in rect.top..rect.bottom {
+                let start = addr + y as u32 * stride + rect.left as u32 * bpp;
+                let width_bytes = ((rect.right - rect.left).max(0) as u32 * bpp) as usize;
+                match bpp {
+                    1 => ctx.memory[start..][..width_bytes].fill(color as u8),
+                    4 => {
+                        for x in 0..(rect.right - rect.left).max(0) as u32 {
+                            ctx.memory.write::<u32>(start + x * 4, color);
+                        }
+                    }
+                    _ => todo!("Blt colorfill bpp {bpp}"),
+                }
+            }
+            dst.present(&mut ctx.memory);
+            return DD::OK;
+        }
+
+        let color_key = if dwFlags & DDBLT_KEYSRCOVERRIDE != 0 {
+            // DDBLTFX.ddckSrcColorkey, past the z-buffer and alpha fields.
+            Some(ColorKey {
+                low: ctx.memory.read::<u32>(lpDDBLTFX + 92),
+                high: ctx.memory.read::<u32>(lpDDBLTFX + 96),
+            })
+        } else if dwFlags & DDBLT_KEYSRC != 0 {
+            surface_src_color_key(lpDDSrcSurface)
+        } else {
+            None
+        };
+
+        let src_rect = read_rect(ctx, lpSrcRect);
+        blit_copy(ctx, this, dst_rect, lpDDSrcSurface, src_rect, color_key);
+        DD::OK
+    }
+
+    fn surface_src_color_key(surface: u32) -> Option<ColorKey> {
+        let surfaces = state().surf.borrow();
+        let key = surfaces.get(&surface)?.borrow().src_color_key;
+        if key.is_none() {
+            log::warn!("blit asked for a source color key, but none is set");
+        }
+        key
     }
 
     #[win32_derive::dllexport]
@@ -292,8 +554,62 @@ pub mod IDirectDrawSurface {
     }
 
     #[win32_derive::dllexport]
-    pub fn BltFast(_ctx: &mut Context, _this: u32) -> DD {
-        todo!()
+    pub fn BltFast(
+        ctx: &mut Context,
+        this: u32,
+        dwX: u32,
+        dwY: u32,
+        lpDDSrcSurface: u32,
+        lpSrcRect: u32,
+        dwTrans: u32,
+    ) -> DD {
+        const DDBLTFAST_SRCCOLORKEY: u32 = 0x0001;
+        const DDBLTFAST_DESTCOLORKEY: u32 = 0x0002;
+        const DDBLTFAST_WAIT: u32 = 0x0010;
+        const KNOWN: u32 = DDBLTFAST_SRCCOLORKEY | DDBLTFAST_DESTCOLORKEY | DDBLTFAST_WAIT;
+        if dwTrans & !KNOWN != 0 {
+            log::warn!("BltFast: ignoring flags {:#x}", dwTrans & !KNOWN);
+        }
+        if dwTrans & DDBLTFAST_DESTCOLORKEY != 0 {
+            // Would need to test the destination pixel rather than the source;
+            // no caller has needed it.
+            log::warn!("BltFast: destination color key not supported");
+        }
+        let color_key = if dwTrans & DDBLTFAST_SRCCOLORKEY != 0 {
+            surface_src_color_key(lpDDSrcSurface)
+        } else {
+            None
+        };
+
+        let src_rect = read_rect(ctx, lpSrcRect);
+        let (w, h) = match &src_rect {
+            Some(r) => ((r.right - r.left).max(0), (r.bottom - r.top).max(0)),
+            None => {
+                let src = state()
+                    .surf
+                    .borrow_mut()
+                    .get(&lpDDSrcSurface)
+                    .unwrap()
+                    .clone();
+                let src = src.borrow();
+                (src.width as i32, src.height as i32)
+            }
+        };
+        let dst_rect = RECT {
+            left: dwX as i32,
+            top: dwY as i32,
+            right: dwX as i32 + w,
+            bottom: dwY as i32 + h,
+        };
+        blit_copy(
+            ctx,
+            this,
+            Some(dst_rect),
+            lpDDSrcSurface,
+            src_rect,
+            color_key,
+        );
+        DD::OK
     }
 
     #[win32_derive::dllexport]
@@ -318,9 +634,14 @@ pub mod IDirectDrawSurface {
         _lpDDSurfaceTargetOverride: u32,
         _dwFlags: u32,
     ) -> DD {
-        let surfaces = state().surf.borrow_mut();
-        let mut surface = surfaces.get(&this).unwrap().borrow_mut();
-        surface.flip(&mut ctx.memory);
+        {
+            let surfaces = state().surf.borrow_mut();
+            let mut surface = surfaces.get(&this).unwrap().borrow_mut();
+            surface.flip(&mut ctx.memory);
+        }
+        // A frame flip is the one thing a game does every frame no matter what
+        // it's doing, so it's where we keep the audio mixer fed.
+        crate::dsound::pump(ctx);
         DD::OK
     }
 
@@ -346,8 +667,10 @@ pub mod IDirectDrawSurface {
     }
 
     #[win32_derive::dllexport]
-    pub fn GetCaps(_ctx: &mut Context, _this: u32) -> DD {
-        todo!()
+    pub fn GetCaps(ctx: &mut Context, _this: u32, lpDDSCaps: u32) -> DD {
+        let caps = DDSCAPS::BACKBUFFER | DDSCAPS::COMPLEX | DDSCAPS::FLIP | DDSCAPS::VIDEOMEMORY;
+        ctx.memory.write::<u32>(lpDDSCaps, caps.bits());
+        DD::OK
     }
 
     #[win32_derive::dllexport]
@@ -356,8 +679,25 @@ pub mod IDirectDrawSurface {
     }
 
     #[win32_derive::dllexport]
-    pub fn GetColorKey(_ctx: &mut Context, _this: u32) -> DD {
-        todo!()
+    pub fn GetColorKey(ctx: &mut Context, this: u32, dwFlags: u32, lpDDColorKey: u32) -> DD {
+        let key = {
+            let surfaces = state().surf.borrow();
+            let Some(surface) = surfaces.get(&this) else {
+                return DD::ERR_GENERIC;
+            };
+            let surface = surface.borrow();
+            if dwFlags & DDCKEY_DESTBLT != 0 {
+                surface.dst_color_key
+            } else {
+                surface.src_color_key
+            }
+        };
+        let Some(key) = key else {
+            return DD::ERR_NOCOLORKEY;
+        };
+        ctx.memory.write::<u32>(lpDDColorKey, key.low);
+        ctx.memory.write::<u32>(lpDDColorKey + 4, key.high);
+        DD::OK
     }
 
     #[win32_derive::dllexport]
@@ -387,18 +727,55 @@ pub mod IDirectDrawSurface {
     }
 
     #[win32_derive::dllexport]
-    pub fn GetSurfaceDesc(_ctx: &mut Context, _this: u32) -> DD {
-        todo!()
+    pub fn GetSurfaceDesc(ctx: &mut Context, this: u32, lpDDSurfaceDesc: u32) -> DD {
+        let desc = {
+            let surfaces = state().surf.borrow_mut();
+            let surface = surfaces.get(&this).unwrap().borrow();
+            let bpp = surface.bytes_per_pixel * 8;
+            let pixel_format = if bpp == 8 {
+                DDPIXELFORMAT {
+                    dwSize: std::mem::size_of::<DDPIXELFORMAT>() as u32,
+                    dwFlags: 0x40 | 0x20, // DDPF_RGB | DDPF_PALETTEINDEXED8
+                    dwFourCC: 0,
+                    dwRGBBitCount: 8,
+                    dwRBitMask: 0,
+                    dwGBitMask: 0,
+                    dwBBitMask: 0,
+                    dwRGBAlphaBitMask: 0,
+                }
+            } else {
+                get_pixel_format()
+            };
+            DDSURFACEDESC {
+                dwSize: std::mem::size_of::<DDSURFACEDESC>() as u32,
+                dwFlags: DDSD::WIDTH | DDSD::HEIGHT | DDSD::PITCH | DDSD::PIXELFORMAT,
+                dwWidth: surface.width,
+                dwHeight: surface.height,
+                lPitch_dwLinearSize: surface.width * surface.bytes_per_pixel,
+                ddpfPixelFormat: pixel_format,
+                ..DDSURFACEDESC::default()
+            }
+        };
+        desc.write_to_prefix(&mut ctx.memory[lpDDSurfaceDesc..])
+            .unwrap();
+        DD::OK
     }
 
     #[win32_derive::dllexport]
-    pub fn Initialize(_ctx: &mut Context, _this: u32) -> DD {
-        todo!()
+    pub fn Initialize(
+        _ctx: &mut Context,
+        _this: u32,
+        _lpDD: u32,
+        _dwFlags: u32,
+        _lpDDColorTable: u32,
+    ) -> DD {
+        // Nothing to do: the object is fully constructed when it's created.
+        DD::OK
     }
 
     #[win32_derive::dllexport]
     pub fn IsLost(_ctx: &mut Context, _this: u32) -> DD {
-        todo!()
+        DD::OK // our surfaces are never lost
     }
 
     #[win32_derive::dllexport]
@@ -441,8 +818,30 @@ pub mod IDirectDrawSurface {
     }
 
     #[win32_derive::dllexport]
-    pub fn SetColorKey(_ctx: &mut Context, _this: u32) -> DD {
-        todo!()
+    pub fn SetColorKey(ctx: &mut Context, this: u32, dwFlags: u32, lpDDColorKey: u32) -> DD {
+        let key = if lpDDColorKey == 0 {
+            None
+        } else {
+            // DDCOLORKEY: dwColorSpaceLowValue, dwColorSpaceHighValue.
+            Some(ColorKey {
+                low: ctx.memory.read::<u32>(lpDDColorKey),
+                high: ctx.memory.read::<u32>(lpDDColorKey + 4),
+            })
+        };
+        let surfaces = state().surf.borrow();
+        let Some(surface) = surfaces.get(&this) else {
+            return DD::ERR_GENERIC;
+        };
+        let mut surface = surface.borrow_mut();
+        if dwFlags & (DDCKEY_SRCOVERLAY | DDCKEY_DESTOVERLAY) != 0 {
+            log::warn!("SetColorKey: overlays are not supported");
+        }
+        if dwFlags & DDCKEY_DESTBLT != 0 {
+            surface.dst_color_key = key;
+        } else {
+            surface.src_color_key = key;
+        }
+        DD::OK
     }
 
     #[win32_derive::dllexport]
@@ -465,6 +864,7 @@ pub mod IDirectDrawSurface {
     pub fn Unlock(ctx: &mut Context, this: u32, _lpRect: u32) -> DD {
         let surfaces = state().surf.borrow_mut();
         let mut surface = surfaces.get(&this).unwrap().borrow_mut();
+        // unlock presents window-backed surfaces itself.
         surface.unlock(&mut ctx.memory);
         DD::OK
     }
@@ -507,38 +907,94 @@ pub mod IDirectDrawPalette {
     ];
 
     #[win32_derive::dllexport]
-    pub fn QueryInterface(_ctx: &mut Context, _this: u32) -> DD {
-        todo!()
+    pub fn QueryInterface(ctx: &mut Context, _this: u32, riid: u32, _ppvObject: u32) -> DD {
+        let iid = crate::Ptr::<GUID>::new(riid).read(&ctx.memory);
+        log::warn!("IDirectDrawPalette::QueryInterface({iid:?}): not supported");
+        DD::E_NOINTERFACE
     }
 
     #[win32_derive::dllexport]
-    pub fn AddRef(_ctx: &mut Context, _this: u32) -> DD {
-        todo!()
+    pub fn AddRef(_ctx: &mut Context, _this: u32) -> u32 {
+        1
     }
 
     #[win32_derive::dllexport]
-    pub fn Release(_ctx: &mut Context, _this: u32) -> DD {
-        todo!()
+    pub fn Release(ctx: &mut Context, this: u32) -> u32 {
+        // Surfaces hold their own reference to the palette, so dropping it from
+        // the table doesn't disturb anything still displaying it.
+        state().palette.borrow_mut().remove(&this);
+        kernel32::lock().process_heap.free(&mut ctx.memory, this);
+        0
     }
 
     #[win32_derive::dllexport]
-    pub fn GetCaps(_ctx: &mut Context, _this: u32) -> DD {
-        todo!()
+    pub fn GetCaps(ctx: &mut Context, _this: u32, lpdwCaps: u32) -> DD {
+        // We only ever create 8-bit palettes with all 256 entries settable.
+        let caps = DDPCAPS::_8BIT | DDPCAPS::ALLOW256;
+        ctx.memory.write::<u32>(lpdwCaps, caps.bits());
+        DD::OK
     }
 
     #[win32_derive::dllexport]
-    pub fn GetEntries(_ctx: &mut Context, _this: u32) -> DD {
-        todo!()
+    pub fn GetEntries(
+        ctx: &mut Context,
+        this: u32,
+        _dwFlags: u32,
+        dwBase: u32,
+        dwNumEntries: u32,
+        lpEntries: u32,
+    ) -> DD {
+        let palettes = state().palette.borrow();
+        let Some(palette) = palettes.get(&this) else {
+            return DD::ERR_GENERIC;
+        };
+        let palette = palette.borrow();
+        for i in 0..dwNumEntries {
+            let Some(entry) = palette.entries.get((dwBase + i) as usize) else {
+                break;
+            };
+            ctx.memory.write(lpEntries + i * 4, entry.clone());
+        }
+        DD::OK
     }
 
     #[win32_derive::dllexport]
-    pub fn Initialize(_ctx: &mut Context, _this: u32) -> DD {
-        todo!()
+    pub fn Initialize(
+        _ctx: &mut Context,
+        _this: u32,
+        _lpDD: u32,
+        _dwFlags: u32,
+        _lpDDColorTable: u32,
+    ) -> DD {
+        // Nothing to do: the object is fully constructed when it's created.
+        DD::OK
     }
 
     #[win32_derive::dllexport]
-    pub fn SetEntries(_ctx: &mut Context, _this: u32) -> DD {
-        todo!()
+    pub fn SetEntries(
+        ctx: &mut Context,
+        this: u32,
+        _dwFlags: u32,
+        dwStartingEntry: u32,
+        dwCount: u32,
+        lpEntries: u32,
+    ) -> DD {
+        let new_entries = <[PALETTEENTRY]>::ref_from_prefix_with_elems(
+            &ctx.memory[lpEntries..],
+            dwCount as usize,
+        )
+        .unwrap()
+        .0
+        .to_vec();
+        let palettes = state().palette.borrow_mut();
+        let mut palette = palettes.get(&this).unwrap().borrow_mut();
+        for (i, entry) in new_entries.into_iter().enumerate() {
+            let index = dwStartingEntry as usize + i;
+            if index < palette.entries.len() {
+                palette.entries[index] = entry;
+            }
+        }
+        DD::OK
     }
 
     pub static mut VTABLE: u32 = 0;

--- a/win32/winapi/src/ddraw/ddraw1.rs
+++ b/win32/winapi/src/ddraw/ddraw1.rs
@@ -5,7 +5,12 @@ use zerocopy::{FromBytes, IntoBytes};
 
 use crate::{
     RECT,
-    ddraw::{ColorKey, DD, GUID, Palette, get_pixel_format, state, types::*},
+    ddraw::{
+        ColorKey, DD, GUID, Palette,
+        ddraw::{blit_copy, read_rect, surface_src_color_key},
+        get_pixel_format, state,
+        types::*,
+    },
     heap::Heap,
     kernel32, stub,
     user32::HWND,
@@ -384,96 +389,6 @@ pub mod IDirectDrawSurface {
         todo!()
     }
 
-    fn read_rect(ctx: &Context, addr: u32) -> Option<RECT> {
-        if addr == 0 {
-            None
-        } else {
-            crate::Ptr::<RECT>::new(addr).read(&ctx.memory)
-        }
-    }
-
-    /// Copy a rect between two surfaces (which may be the same one; the copy
-    /// stages through a temporary buffer).
-    ///
-    /// With a `color_key`, source pixels inside its range are left alone in the
-    /// destination, which is how sprites get transparent backgrounds.
-    pub fn blit_copy(
-        ctx: &mut Context,
-        dst_ptr: u32,
-        dst_rect: Option<RECT>,
-        src_ptr: u32,
-        src_rect: Option<RECT>,
-        color_key: Option<ColorKey>,
-    ) {
-        let src_rc = state().surf.borrow_mut().get(&src_ptr).unwrap().clone();
-        let dst_rc = state().surf.borrow_mut().get(&dst_ptr).unwrap().clone();
-
-        let (rows, row_bytes, row_count, bpp) = {
-            let mut src = src_rc.borrow_mut();
-            let addr = src.lock(&mut ctx.memory);
-            let bpp = src.bytes_per_pixel;
-            let stride = src.width * bpp;
-            let rect = src_rect
-                .unwrap_or_else(|| RECT::from_size(src.width, src.height))
-                .clip_to_size(src.width, src.height);
-            let row_bytes = ((rect.right - rect.left).max(0) as u32 * bpp) as usize;
-            let row_count = (rect.bottom - rect.top).max(0) as usize;
-            let mut rows = Vec::with_capacity(row_bytes * row_count);
-            for y in rect.top..rect.bottom {
-                let start = addr + y as u32 * stride + rect.left as u32 * bpp;
-                rows.extend_from_slice(&ctx.memory[start..][..row_bytes]);
-            }
-            (rows, row_bytes, row_count, bpp)
-        };
-
-        let mut dst = dst_rc.borrow_mut();
-        if dst.bytes_per_pixel != bpp {
-            log::warn!("blit between different pixel formats");
-            return;
-        }
-        let addr = dst.lock(&mut ctx.memory);
-        let stride = dst.width * bpp;
-        let want = dst_rect.unwrap_or_else(|| RECT::from_size(dst.width, dst.height));
-        let rect = want.clip_to_size(dst.width, dst.height);
-        // Whatever the clip took off the top and left has to come off the
-        // source as well, otherwise the image slides instead of being cropped.
-        let skip_x = (rect.left - want.left).max(0) as usize * bpp as usize;
-        let skip_y = (rect.top - want.top).max(0) as usize;
-        // No stretching: copy 1:1, clipped to both rects.
-        let copy_bytes = row_bytes
-            .saturating_sub(skip_x)
-            .min(((rect.right - rect.left).max(0) as u32 * bpp) as usize);
-        let copy_rows = row_count
-            .saturating_sub(skip_y)
-            .min((rect.bottom - rect.top).max(0) as usize);
-        for i in 0..copy_rows {
-            let dst_start = addr + (rect.top + i as i32) as u32 * stride + rect.left as u32 * bpp;
-            let row = &rows[(i + skip_y) * row_bytes + skip_x..][..copy_bytes];
-            match color_key {
-                None => ctx.memory[dst_start..][..copy_bytes].copy_from_slice(row),
-                Some(key) => {
-                    for (x, pixel) in row.chunks_exact(bpp as usize).enumerate() {
-                        let value = match bpp {
-                            1 => pixel[0] as u32,
-                            2 => u16::from_le_bytes(pixel.try_into().unwrap()) as u32,
-                            4 => u32::from_le_bytes(pixel.try_into().unwrap()),
-                            _ => {
-                                log::warn!("colorkey blit at {bpp} bytes per pixel");
-                                return;
-                            }
-                        };
-                        if key.matches(value) {
-                            continue;
-                        }
-                        let at = dst_start + x as u32 * bpp;
-                        ctx.memory[at..][..bpp as usize].copy_from_slice(pixel);
-                    }
-                }
-            }
-        }
-        dst.present(&mut ctx.memory);
-    }
-
     #[win32_derive::dllexport]
     pub fn Blt(
         ctx: &mut Context,
@@ -484,68 +399,15 @@ pub mod IDirectDrawSurface {
         dwFlags: u32,
         lpDDBLTFX: u32,
     ) -> DD {
-        const DDBLT_COLORFILL: u32 = 0x0400;
-        const DDBLT_KEYSRC: u32 = 0x8000;
-        const DDBLT_KEYSRCOVERRIDE: u32 = 0x0001_0000;
-        const DDBLT_WAIT: u32 = 0x0100_0000;
-        const KNOWN: u32 = DDBLT_COLORFILL | DDBLT_KEYSRC | DDBLT_KEYSRCOVERRIDE | DDBLT_WAIT;
-        if dwFlags & !KNOWN != 0 {
-            log::warn!("Blt: ignoring flags {:#x}", dwFlags & !KNOWN);
-        }
-
-        let dst_rect = read_rect(ctx, lpDstRect);
-        if dwFlags & DDBLT_COLORFILL != 0 {
-            // DDBLTFX.dwFillColor is at offset 80.
-            let color = ctx.memory.read::<u32>(lpDDBLTFX + 80);
-            let dst_rc = state().surf.borrow_mut().get(&this).unwrap().clone();
-            let mut dst = dst_rc.borrow_mut();
-            let bpp = dst.bytes_per_pixel;
-            let rect = dst_rect
-                .unwrap_or_else(|| RECT::from_size(dst.width, dst.height))
-                .clip_to_size(dst.width, dst.height);
-            let addr = dst.lock(&mut ctx.memory);
-            let stride = dst.width * bpp;
-            for y in rect.top..rect.bottom {
-                let start = addr + y as u32 * stride + rect.left as u32 * bpp;
-                let width_bytes = ((rect.right - rect.left).max(0) as u32 * bpp) as usize;
-                match bpp {
-                    1 => ctx.memory[start..][..width_bytes].fill(color as u8),
-                    4 => {
-                        for x in 0..(rect.right - rect.left).max(0) as u32 {
-                            ctx.memory.write::<u32>(start + x * 4, color);
-                        }
-                    }
-                    _ => todo!("Blt colorfill bpp {bpp}"),
-                }
-            }
-            dst.present(&mut ctx.memory);
-            return DD::OK;
-        }
-
-        let color_key = if dwFlags & DDBLT_KEYSRCOVERRIDE != 0 {
-            // DDBLTFX.ddckSrcColorkey, past the z-buffer and alpha fields.
-            Some(ColorKey {
-                low: ctx.memory.read::<u32>(lpDDBLTFX + 92),
-                high: ctx.memory.read::<u32>(lpDDBLTFX + 96),
-            })
-        } else if dwFlags & DDBLT_KEYSRC != 0 {
-            surface_src_color_key(lpDDSrcSurface)
-        } else {
-            None
-        };
-
-        let src_rect = read_rect(ctx, lpSrcRect);
-        blit_copy(ctx, this, dst_rect, lpDDSrcSurface, src_rect, color_key);
-        DD::OK
-    }
-
-    fn surface_src_color_key(surface: u32) -> Option<ColorKey> {
-        let surfaces = state().surf.borrow();
-        let key = surfaces.get(&surface)?.borrow().src_color_key;
-        if key.is_none() {
-            log::warn!("blit asked for a source color key, but none is set");
-        }
-        key
+        crate::ddraw::ddraw::blt(
+            ctx,
+            this,
+            lpDstRect,
+            lpDDSrcSurface,
+            lpSrcRect,
+            dwFlags,
+            lpDDBLTFX,
+        )
     }
 
     #[win32_derive::dllexport]
@@ -563,53 +425,7 @@ pub mod IDirectDrawSurface {
         lpSrcRect: u32,
         dwTrans: u32,
     ) -> DD {
-        const DDBLTFAST_SRCCOLORKEY: u32 = 0x0001;
-        const DDBLTFAST_DESTCOLORKEY: u32 = 0x0002;
-        const DDBLTFAST_WAIT: u32 = 0x0010;
-        const KNOWN: u32 = DDBLTFAST_SRCCOLORKEY | DDBLTFAST_DESTCOLORKEY | DDBLTFAST_WAIT;
-        if dwTrans & !KNOWN != 0 {
-            log::warn!("BltFast: ignoring flags {:#x}", dwTrans & !KNOWN);
-        }
-        if dwTrans & DDBLTFAST_DESTCOLORKEY != 0 {
-            // Would need to test the destination pixel rather than the source;
-            // no caller has needed it.
-            log::warn!("BltFast: destination color key not supported");
-        }
-        let color_key = if dwTrans & DDBLTFAST_SRCCOLORKEY != 0 {
-            surface_src_color_key(lpDDSrcSurface)
-        } else {
-            None
-        };
-
-        let src_rect = read_rect(ctx, lpSrcRect);
-        let (w, h) = match &src_rect {
-            Some(r) => ((r.right - r.left).max(0), (r.bottom - r.top).max(0)),
-            None => {
-                let src = state()
-                    .surf
-                    .borrow_mut()
-                    .get(&lpDDSrcSurface)
-                    .unwrap()
-                    .clone();
-                let src = src.borrow();
-                (src.width as i32, src.height as i32)
-            }
-        };
-        let dst_rect = RECT {
-            left: dwX as i32,
-            top: dwY as i32,
-            right: dwX as i32 + w,
-            bottom: dwY as i32 + h,
-        };
-        blit_copy(
-            ctx,
-            this,
-            Some(dst_rect),
-            lpDDSrcSurface,
-            src_rect,
-            color_key,
-        );
-        DD::OK
+        crate::ddraw::ddraw::blt_fast(ctx, this, dwX, dwY, lpDDSrcSurface, lpSrcRect, dwTrans)
     }
 
     #[win32_derive::dllexport]
@@ -680,24 +496,12 @@ pub mod IDirectDrawSurface {
 
     #[win32_derive::dllexport]
     pub fn GetColorKey(ctx: &mut Context, this: u32, dwFlags: u32, lpDDColorKey: u32) -> DD {
-        let key = {
-            let surfaces = state().surf.borrow();
-            let Some(surface) = surfaces.get(&this) else {
-                return DD::ERR_GENERIC;
-            };
-            let surface = surface.borrow();
-            if dwFlags & DDCKEY_DESTBLT != 0 {
-                surface.dst_color_key
-            } else {
-                surface.src_color_key
-            }
-        };
-        let Some(key) = key else {
-            return DD::ERR_NOCOLORKEY;
-        };
-        ctx.memory.write::<u32>(lpDDColorKey, key.low);
-        ctx.memory.write::<u32>(lpDDColorKey + 4, key.high);
-        DD::OK
+        crate::ddraw::ddraw::get_color_key(ctx, this, dwFlags, lpDDColorKey)
+    }
+
+    #[win32_derive::dllexport]
+    pub fn SetColorKey(ctx: &mut Context, this: u32, dwFlags: u32, lpDDColorKey: u32) -> DD {
+        crate::ddraw::ddraw::set_color_key(ctx, this, dwFlags, lpDDColorKey)
     }
 
     #[win32_derive::dllexport]
@@ -815,33 +619,6 @@ pub mod IDirectDrawSurface {
     #[win32_derive::dllexport]
     pub fn SetClipper(_ctx: &mut Context, _this: u32) -> DD {
         todo!()
-    }
-
-    #[win32_derive::dllexport]
-    pub fn SetColorKey(ctx: &mut Context, this: u32, dwFlags: u32, lpDDColorKey: u32) -> DD {
-        let key = if lpDDColorKey == 0 {
-            None
-        } else {
-            // DDCOLORKEY: dwColorSpaceLowValue, dwColorSpaceHighValue.
-            Some(ColorKey {
-                low: ctx.memory.read::<u32>(lpDDColorKey),
-                high: ctx.memory.read::<u32>(lpDDColorKey + 4),
-            })
-        };
-        let surfaces = state().surf.borrow();
-        let Some(surface) = surfaces.get(&this) else {
-            return DD::ERR_GENERIC;
-        };
-        let mut surface = surface.borrow_mut();
-        if dwFlags & (DDCKEY_SRCOVERLAY | DDCKEY_DESTOVERLAY) != 0 {
-            log::warn!("SetColorKey: overlays are not supported");
-        }
-        if dwFlags & DDCKEY_DESTBLT != 0 {
-            surface.dst_color_key = key;
-        } else {
-            surface.src_color_key = key;
-        }
-        DD::OK
     }
 
     #[win32_derive::dllexport]

--- a/win32/winapi/src/ddraw/ddraw7.rs
+++ b/win32/winapi/src/ddraw/ddraw7.rs
@@ -375,15 +375,25 @@ pub mod IDirectDrawSurface7 {
 
     #[win32_derive::dllexport]
     pub fn Blt(
-        _ctx: &mut Context,
-        _this: u32,
-        _lpDestRect: u32,
-        _lpDDSrcSurface: u32,
-        _lpSrcRect: u32,
-        _dwFlags: u32,
-        _lpDDBltFx: u32,
+        ctx: &mut Context,
+        this: u32,
+        lpDestRect: u32,
+        lpDDSrcSurface: u32,
+        lpSrcRect: u32,
+        dwFlags: u32,
+        lpDDBltFx: u32,
     ) -> DD {
-        todo!()
+        // Surfaces are shared between interface versions, so the version 1
+        // implementation covers both.
+        crate::ddraw::ddraw1::IDirectDrawSurface::Blt(
+            ctx,
+            this,
+            lpDestRect,
+            lpDDSrcSurface,
+            lpSrcRect,
+            dwFlags,
+            lpDDBltFx,
+        )
     }
 
     #[win32_derive::dllexport]
@@ -405,44 +415,24 @@ pub mod IDirectDrawSurface7 {
         dwY: u32,
         lpDDSrcSurface: u32,
         lpSrcRect: Ptr<RECT>,
-        _dwTrans: u32,
+        dwTrans: u32,
     ) -> DD {
-        let surfaces = state().surf.borrow_mut();
-        let mut dst_surface = surfaces.get(&this).unwrap().borrow_mut();
-        let mut src_surface = surfaces.get(&lpDDSrcSurface).unwrap().borrow_mut();
-
-        assert_eq!(src_surface.bytes_per_pixel, 4);
-        assert_eq!(dst_surface.bytes_per_pixel, 4);
-        let bytes_per_pixel = src_surface.bytes_per_pixel;
-        let src_stride = src_surface.width * bytes_per_pixel;
-        let dst_stride = dst_surface.width * bytes_per_pixel;
-
-        let src_rect = lpSrcRect.read(&ctx.memory).unwrap();
-        let src_addr = src_surface.lock(&mut ctx.memory);
-        let dst_addr = dst_surface.lock(&mut ctx.memory);
-
-        let [src_pixels, dst_pixels] = ctx
-            .memory
-            .bytes
-            .get_disjoint_mut([
-                src_addr as usize..(src_addr + src_surface.height * src_stride) as usize,
-                dst_addr as usize..(dst_addr + dst_surface.height * dst_stride) as usize,
-            ])
-            .unwrap();
-
-        let width = ((src_rect.right - src_rect.left) as u32 * bytes_per_pixel) as usize;
-        for (sy, dy) in (src_rect.top as u32..src_rect.bottom as u32).zip(dwY..) {
-            let src_row = &src_pixels[(sy * src_stride) as usize..];
-            let dst_row = &mut dst_pixels[(dy * dst_stride) as usize..];
-            dst_row[(dwX * bytes_per_pixel) as usize..][..width].copy_from_slice(
-                &src_row[(src_rect.left as u32 * bytes_per_pixel) as usize..][..width],
-            );
+        let result = crate::ddraw::ddraw1::IDirectDrawSurface::BltFast(
+            ctx,
+            this,
+            dwX,
+            dwY,
+            lpDDSrcSurface,
+            lpSrcRect.addr,
+            dwTrans,
+        );
+        // Apps on this interface draw to an offscreen surface and expect to see
+        // the result without flipping, so refresh its texture here.
+        let surfaces = state().surf.borrow();
+        if let Some(surface) = surfaces.get(&this) {
+            surface.borrow_mut().unlock(&mut ctx.memory);
         }
-
-        src_surface.unlock(&mut ctx.memory);
-        dst_surface.unlock(&mut ctx.memory);
-
-        stub!(DD::OK)
+        result
     }
 
     #[win32_derive::dllexport]
@@ -483,9 +473,14 @@ pub mod IDirectDrawSurface7 {
         _lpDDSurfaceTargetOverride: u32,
         _dwFlags: u32,
     ) -> DD {
-        let surfaces = state().surf.borrow_mut();
-        let mut surface = surfaces.get(&this).unwrap().borrow_mut();
-        surface.flip(&mut ctx.memory);
+        {
+            let surfaces = state().surf.borrow_mut();
+            let mut surface = surfaces.get(&this).unwrap().borrow_mut();
+            surface.flip(&mut ctx.memory);
+        }
+        // A frame flip is the one thing a game does every frame no matter what
+        // it's doing, so it's where we keep the audio mixer fed.
+        crate::dsound::pump(ctx);
         DD::OK
     }
 
@@ -521,8 +516,8 @@ pub mod IDirectDrawSurface7 {
     }
 
     #[win32_derive::dllexport]
-    pub fn GetColorKey(_ctx: &mut Context, _this: u32, _dwFlags: u32, _lpDDColorKey: u32) -> DD {
-        todo!()
+    pub fn GetColorKey(ctx: &mut Context, this: u32, dwFlags: u32, lpDDColorKey: u32) -> DD {
+        crate::ddraw::ddraw1::IDirectDrawSurface::GetColorKey(ctx, this, dwFlags, lpDDColorKey)
     }
 
     #[win32_derive::dllexport]
@@ -621,8 +616,8 @@ pub mod IDirectDrawSurface7 {
     }
 
     #[win32_derive::dllexport]
-    pub fn SetColorKey(_ctx: &mut Context, _this: u32, _dwFlags: u32, _lpDDColorKey: u32) -> DD {
-        todo!()
+    pub fn SetColorKey(ctx: &mut Context, this: u32, dwFlags: u32, lpDDColorKey: u32) -> DD {
+        crate::ddraw::ddraw1::IDirectDrawSurface::SetColorKey(ctx, this, dwFlags, lpDDColorKey)
     }
 
     #[win32_derive::dllexport]

--- a/win32/winapi/src/ddraw/ddraw7.rs
+++ b/win32/winapi/src/ddraw/ddraw7.rs
@@ -383,9 +383,7 @@ pub mod IDirectDrawSurface7 {
         dwFlags: u32,
         lpDDBltFx: u32,
     ) -> DD {
-        // Surfaces are shared between interface versions, so the version 1
-        // implementation covers both.
-        crate::ddraw::ddraw1::IDirectDrawSurface::Blt(
+        crate::ddraw::ddraw::blt(
             ctx,
             this,
             lpDestRect,
@@ -417,7 +415,7 @@ pub mod IDirectDrawSurface7 {
         lpSrcRect: Ptr<RECT>,
         dwTrans: u32,
     ) -> DD {
-        let result = crate::ddraw::ddraw1::IDirectDrawSurface::BltFast(
+        let result = crate::ddraw::ddraw::blt_fast(
             ctx,
             this,
             dwX,
@@ -517,7 +515,7 @@ pub mod IDirectDrawSurface7 {
 
     #[win32_derive::dllexport]
     pub fn GetColorKey(ctx: &mut Context, this: u32, dwFlags: u32, lpDDColorKey: u32) -> DD {
-        crate::ddraw::ddraw1::IDirectDrawSurface::GetColorKey(ctx, this, dwFlags, lpDDColorKey)
+        crate::ddraw::ddraw::get_color_key(ctx, this, dwFlags, lpDDColorKey)
     }
 
     #[win32_derive::dllexport]
@@ -617,7 +615,7 @@ pub mod IDirectDrawSurface7 {
 
     #[win32_derive::dllexport]
     pub fn SetColorKey(ctx: &mut Context, this: u32, dwFlags: u32, lpDDColorKey: u32) -> DD {
-        crate::ddraw::ddraw1::IDirectDrawSurface::SetColorKey(ctx, this, dwFlags, lpDDColorKey)
+        crate::ddraw::ddraw::set_color_key(ctx, this, dwFlags, lpDDColorKey)
     }
 
     #[win32_derive::dllexport]

--- a/win32/winapi/src/ddraw/types.rs
+++ b/win32/winapi/src/ddraw/types.rs
@@ -10,7 +10,15 @@ pub enum DD {
     OK = 0,
     E_NOINTERFACE = 0x80004002,
     ERR_GENERIC = 0x80004005,
+    ERR_NOCOLORKEY = 0x887600d4,
 }
+
+/// DDCKEY_* flags, selecting which of a surface's color keys an operation
+/// refers to.
+pub const DDCKEY_DESTOVERLAY: u32 = 0x0001;
+pub const DDCKEY_DESTBLT: u32 = 0x0002;
+pub const DDCKEY_SRCOVERLAY: u32 = 0x0004;
+pub const DDCKEY_SRCBLT: u32 = 0x0008;
 
 impl Into<ABIReturn> for DD {
     fn into(self) -> ABIReturn {
@@ -135,8 +143,8 @@ win32flags! {
     zerocopy::IntoBytes,
 )]
 pub struct DDCOLORKEY {
-    dwColorSpaceLowValue: u32,
-    dwColorSpaceHighValue: u32,
+    pub dwColorSpaceLowValue: u32,
+    pub dwColorSpaceHighValue: u32,
 }
 
 #[repr(C)]
@@ -490,7 +498,14 @@ win32flags! {
 }
 
 #[repr(C)]
-#[derive(Debug, Clone, zerocopy::FromBytes, zerocopy::Immutable, zerocopy::KnownLayout)]
+#[derive(
+    Debug,
+    Clone,
+    zerocopy::FromBytes,
+    zerocopy::IntoBytes,
+    zerocopy::Immutable,
+    zerocopy::KnownLayout,
+)]
 pub struct PALETTEENTRY {
     pub peRed: u8,
     pub peGreen: u8,

--- a/win32/winapi/src/rect.rs
+++ b/win32/winapi/src/rect.rs
@@ -21,6 +21,16 @@ pub struct RECT {
 }
 
 impl RECT {
+    /// The whole of something that size, starting at the origin.
+    pub fn from_size(width: u32, height: u32) -> RECT {
+        RECT {
+            left: 0,
+            top: 0,
+            right: width as i32,
+            bottom: height as i32,
+        }
+    }
+
     pub fn clip(&self, other: &RECT) -> RECT {
         RECT {
             left: self.left.max(other.left),
@@ -28,6 +38,11 @@ impl RECT {
             right: self.right.min(other.right),
             bottom: self.bottom.min(other.bottom),
         }
+    }
+
+    /// Clip to the bounds of something that size.
+    pub fn clip_to_size(&self, width: u32, height: u32) -> RECT {
+        self.clip(&RECT::from_size(width, height))
     }
 
     pub fn origin(&self) -> POINT {


### PR DESCRIPTION


Part 13 of 15, splitting up #1. Needs 9 merged first; on its own it does not compile.
