### PR TITLE
winapi: keep the mappings the program declared

### DIFF
--- a/win32/winapi/src/lib.rs
+++ b/win32/winapi/src/lib.rs
@@ -68,6 +68,9 @@ pub fn load(exe: &EXEData) -> Context {
     (exe.init)(&mut memory, &mut mappings);
 
     let mut lock = kernel32::lock();
+    // The mappings the program declared have to reach the state, or every
+    // later allocation hands out addresses the program is already using.
+    lock.mappings = mappings;
     let mut ctx = Context {
         cpu: CPU::default(),
         thread_handle: lock.objects.add(kernel32::Object::Thread).to_raw(),


### PR DESCRIPTION
`load` fills a fresh `Mappings` from `exe.init` and then drops it, so the state ends up with none of the mappings the program declared. Every allocation after that (VirtualAlloc, the process heap, dsound's buffer heap) is handed addresses the program is already using, and it corrupts itself.

Caught it because winpin started dying with "jmp to null ptr" right after ab6fc8e..b4aacc1 landed, and this one line brings it back. Programs that allocate little would not notice.
