### PR TITLE
strip any extension from imported dll names

### DIFF
--- a/tc/src/exe.rs
+++ b/tc/src/exe.rs
@@ -106,7 +106,11 @@ fn read_imports(pe_file: &exe::PE, mem: &Memory) -> Vec<Import> {
         let name = std::str::from_utf8(imp.image_name(image))
             .unwrap()
             .to_lowercase();
-        let name = name.trim_end_matches(".dll");
+        // The module name doubles as a Rust module path, so drop the extension
+        // (.dll, or .drv for winspool).
+        let name = name
+            .rsplit_once('.')
+            .map_or(name.as_str(), |(stem, _)| stem);
         for (addr, entry) in imp.iat_iter(image) {
             let func = match entry.as_import_symbol(image) {
                 exe::ImportSymbol::Name(name) => std::str::from_utf8(name).unwrap().to_string(),


### PR DESCRIPTION
If you rather I add another check specifically for `.drv` instead I'd be happy to do that instead!

From Claude Fable 5.1 (high):

> The imported module name doubles as a Rust module path, and only .dll was being trimmed. WINSPOOL.DRV produced a path with a dot in it. Drop whatever extension is present instead.