### PR TITLE
GetDlgItem reports no control instead of panicking

### DIFF
--- a/win32/winapi/src/user32/dialog.rs
+++ b/win32/winapi/src/user32/dialog.rs
@@ -63,7 +63,9 @@ pub fn IsDlgButtonChecked(_ctx: &mut Context, _hDlg: HWND, _nIDButton: i32) -> u
 
 #[win32_derive::dllexport]
 pub fn GetDlgItem(_ctx: &mut Context, _hDlg: HWND, _nIDDlgItem: i32) -> HWND {
-    todo!()
+    // Dialog boxes are stubbed out (see DialogBoxParamA), so there are no
+    // controls to find.
+    stub!(HWND::null())
 }
 
 #[win32_derive::dllexport]


### PR DESCRIPTION
Claude Fable 5.1 (high):

> Dialog boxes are stubbed out, so a program asking for one of their controls gets a null HWND and a warning, the way the other dialog stubs answer, rather than a panic.