### PR TITLE
decode non-UTF-8 strings as Latin-1 instead of panicking

### DIFF
--- a/dos/src/dosapi.rs
+++ b/dos/src/dosapi.rs
@@ -83,7 +83,7 @@ pub fn int21(ctx: &mut Context) -> Option<runtime::Cont> {
                 log::warn!("TODO: file access {access:x}");
             }
             let mut state = state();
-            let Some(buf) = state.read_file(name) else {
+            let Some(buf) = state.read_file(&name) else {
                 log::warn!("open {name:?}: not found");
                 ctx.cpu.regs.set_ax(/* file not found */ 2);
                 ctx.cpu.flags.insert(runtime::Flags::CF);
@@ -205,7 +205,7 @@ pub fn int21(ctx: &mut Context) -> Option<runtime::Cont> {
                     let seg = ctx.memory.read::<u16>(params_addr);
                     let relo = ctx.memory.read::<u16>(params_addr + 2);
 
-                    let Some(buf) = state().read_file(cmd) else {
+                    let Some(buf) = state().read_file(&cmd) else {
                         panic!()
                     };
                     let header = exe::DOS::parse(&buf).unwrap();

--- a/runtime/src/memory.rs
+++ b/runtime/src/memory.rs
@@ -70,8 +70,15 @@ impl<'a> Memory<'a> {
         &buf[..nul]
     }
 
-    pub fn read_str(&self, addr: u32) -> &str {
-        std::str::from_utf8(self.read_cstr(addr)).unwrap()
+    /// Read a NUL-terminated string. Programs of this era use the Windows-1252
+    /// code page, so bytes that aren't valid UTF-8 are decoded as Latin-1
+    /// (into an owned string) rather than rejected.
+    pub fn read_str(&self, addr: u32) -> std::borrow::Cow<'_, str> {
+        let buf = self.read_cstr(addr);
+        match std::str::from_utf8(buf) {
+            Ok(s) => std::borrow::Cow::Borrowed(s),
+            Err(_) => std::borrow::Cow::Owned(buf.iter().map(|&b| b as char).collect()),
+        }
     }
 
     /// This returns an allocated string rather than a reference due to alignment.

--- a/runtime/src/memory.rs
+++ b/runtime/src/memory.rs
@@ -62,12 +62,16 @@ impl<'a> Memory<'a> {
             .unwrap();
     }
 
-    pub fn read_str(&self, addr: u32) -> &str {
+    /// Read the bytes of a NUL-terminated string, without the terminator.
+    pub fn read_cstr(&self, addr: u32) -> &[u8] {
         self.check_access(addr);
         let buf = &self.bytes[addr as usize..];
         let nul = buf.iter().position(|&c| c == 0).unwrap();
-        let buf = &buf[..nul];
-        std::str::from_utf8(buf).unwrap()
+        &buf[..nul]
+    }
+
+    pub fn read_str(&self, addr: u32) -> &str {
+        std::str::from_utf8(self.read_cstr(addr)).unwrap()
     }
 
     /// This returns an allocated string rather than a reference due to alignment.

--- a/win32/winapi/src/kernel32/dll.rs
+++ b/win32/winapi/src/kernel32/dll.rs
@@ -111,7 +111,7 @@ pub fn GetModuleFileNameA(
 pub fn GetModuleHandleA(ctx: &mut Context, lpModuleName: Ptr<u8>) -> HMODULE {
     let kernel32 = lock();
     let Some(name) =
-        (lpModuleName.addr != 0).then(|| ctx.memory.read_str(lpModuleName.addr).to_owned())
+        (lpModuleName.addr != 0).then(|| ctx.memory.read_str(lpModuleName.addr).into_owned())
     else {
         // A null name asks for the running executable itself.
         return kernel32.image_base;
@@ -127,7 +127,7 @@ pub fn GetModuleHandleA(ctx: &mut Context, lpModuleName: Ptr<u8>) -> HMODULE {
 
 #[win32_derive::dllexport]
 pub fn LoadLibraryA(ctx: &mut Context, lpLibFileName: Ptr<u8>) -> HMODULE {
-    let filename = ctx.memory.read_str(lpLibFileName.addr).to_owned();
+    let filename = ctx.memory.read_str(lpLibFileName.addr).into_owned();
     let addr = lock().dlls.load_library(&filename);
     if addr == 0 {
         log::warn!("LoadLibrary({filename}): not supported, returning null");
@@ -147,7 +147,7 @@ pub fn GetProcAddress(ctx: &mut Context, hModule: HMODULE, lpProcName: Ptr<u8>) 
     let name = if lpProcName.addr < 0x1000 {
         format!("ordinal{}", lpProcName.addr)
     } else {
-        ctx.memory.read_str(lpProcName.addr).to_owned()
+        ctx.memory.read_str(lpProcName.addr).into_owned()
     };
     let addr = lock().dlls.get_proc_address(hModule, &name);
     if addr == 0 {

--- a/win32/winapi/src/kernel32/file.rs
+++ b/win32/winapi/src/kernel32/file.rs
@@ -115,7 +115,7 @@ pub fn CreateFileA(
     _dwFlagsAndAttributes: u32,
     _hTemplateFile: u32,
 ) -> crate::HANDLE {
-    let name = ctx.memory.read_str(lpFileName.addr).to_owned();
+    let name = ctx.memory.read_str(lpFileName.addr).into_owned();
     let path = resolve_path(&name);
     let write = dwDesiredAccess & GENERIC_WRITE != 0;
     let read = dwDesiredAccess & GENERIC_READ != 0;
@@ -300,7 +300,7 @@ pub fn CloseHandle(_ctx: &mut Context, hObject: crate::HANDLE) -> bool {
 
 #[win32_derive::dllexport]
 pub fn DeleteFileA(ctx: &mut Context, lpFileName: Ptr<u8>) -> bool {
-    let name = ctx.memory.read_str(lpFileName.addr).to_owned();
+    let name = ctx.memory.read_str(lpFileName.addr).into_owned();
     host::fs::remove_file(&resolve_path(&name)).is_ok()
 }
 
@@ -352,7 +352,7 @@ pub fn GetCurrentDirectoryA(ctx: &mut Context, nBufferLength: u32, lpBuffer: Ptr
 
 #[win32_derive::dllexport]
 pub fn SetCurrentDirectoryA(ctx: &mut Context, lpPathName: Ptr<u8>) -> bool {
-    let name = ctx.memory.read_str(lpPathName.addr).to_owned();
+    let name = ctx.memory.read_str(lpPathName.addr).into_owned();
     let path = resolve_path(&name);
     match host::fs::set_current_dir(&path) {
         Ok(()) => true,
@@ -457,7 +457,7 @@ pub fn FindFirstFileA(
     lpFileName: Ptr<u8>,
     lpFindFileData: Ptr<WIN32_FIND_DATAA>,
 ) -> crate::HANDLE {
-    let pattern = ctx.memory.read_str(lpFileName.addr).to_owned();
+    let pattern = ctx.memory.read_str(lpFileName.addr).into_owned();
     let pattern = pattern.replace('\\', "/");
     let (dir, file_pattern) = match pattern.rfind('/') {
         Some(pos) => (&pattern[..pos], &pattern[pos + 1..]),

--- a/win32/winapi/src/kernel32/nls.rs
+++ b/win32/winapi/src/kernel32/nls.rs
@@ -80,7 +80,7 @@ pub fn GetStringTypeA(
         return false;
     }
     let len = if cchSrc < 0 {
-        ctx.memory.read_str(lpSrcStr.addr).len() + 1
+        ctx.memory.read_cstr(lpSrcStr.addr).len() + 1
     } else {
         cchSrc as usize
     };
@@ -147,7 +147,7 @@ pub fn LCMapStringA(
     cchDest: i32,
 ) -> i32 {
     let len = if cchSrc < 0 {
-        ctx.memory.read_str(lpSrcStr.addr).len() as u32 + 1
+        ctx.memory.read_cstr(lpSrcStr.addr).len() as u32 + 1
     } else {
         cchSrc as u32
     };

--- a/win32/winapi/src/kernel32/strings.rs
+++ b/win32/winapi/src/kernel32/strings.rs
@@ -18,14 +18,13 @@ const NORM_IGNORECASE: u32 = 1;
 pub fn lstrlenA(ctx: &mut Context, lpString: Ptr<u8>) -> i32 {
     // A null string faults on Windows too, so let the null page guard catch it
     // rather than inventing a length.
-    ctx.memory.read_str(lpString.addr).len() as i32
+    ctx.memory.read_cstr(lpString.addr).len() as i32
 }
 
 #[win32_derive::dllexport]
 pub fn lstrcpyA(ctx: &mut Context, lpString1: Ptr<u8>, lpString2: Ptr<u8>) -> u32 {
-    let src = ctx.memory.read_str(lpString2.addr).to_owned();
-    let bytes = src.as_bytes();
-    ctx.memory[lpString1.addr..][..bytes.len()].copy_from_slice(bytes);
+    let bytes = ctx.memory.read_cstr(lpString2.addr).to_vec();
+    ctx.memory[lpString1.addr..][..bytes.len()].copy_from_slice(&bytes);
     ctx.memory
         .write::<u8>(lpString1.addr + bytes.len() as u32, 0);
     lpString1.addr
@@ -33,10 +32,9 @@ pub fn lstrcpyA(ctx: &mut Context, lpString1: Ptr<u8>, lpString2: Ptr<u8>) -> u3
 
 #[win32_derive::dllexport]
 pub fn lstrcatA(ctx: &mut Context, lpString1: Ptr<u8>, lpString2: Ptr<u8>) -> u32 {
-    let dst_len = ctx.memory.read_str(lpString1.addr).len() as u32;
-    let src = ctx.memory.read_str(lpString2.addr).to_owned();
-    let bytes = src.as_bytes();
-    ctx.memory[lpString1.addr + dst_len..][..bytes.len()].copy_from_slice(bytes);
+    let dst_len = ctx.memory.read_cstr(lpString1.addr).len() as u32;
+    let bytes = ctx.memory.read_cstr(lpString2.addr).to_vec();
+    ctx.memory[lpString1.addr + dst_len..][..bytes.len()].copy_from_slice(&bytes);
     ctx.memory
         .write::<u8>(lpString1.addr + dst_len + bytes.len() as u32, 0);
     lpString1.addr
@@ -44,7 +42,7 @@ pub fn lstrcatA(ctx: &mut Context, lpString1: Ptr<u8>, lpString2: Ptr<u8>) -> u3
 
 fn read_counted_a(ctx: &Context, addr: u32, count: i32) -> Vec<u8> {
     if count < 0 {
-        ctx.memory.read_str(addr).as_bytes().to_vec()
+        ctx.memory.read_cstr(addr).to_vec()
     } else {
         ctx.memory[addr..][..count as usize].to_vec()
     }

--- a/win32/winapi/src/user32/misc.rs
+++ b/win32/winapi/src/user32/misc.rs
@@ -93,7 +93,7 @@ pub fn MessageBoxA(
         if ptr.addr == 0 {
             String::new()
         } else {
-            ctx.memory.read_str(ptr.addr).to_owned()
+            ctx.memory.read_str(ptr.addr).into_owned()
         }
     };
     log::warn!("MessageBox: {} / {}", read(lpCaption), read(lpText));

--- a/win32/winapi/src/user32/misc.rs
+++ b/win32/winapi/src/user32/misc.rs
@@ -164,10 +164,10 @@ pub fn wsprintfA(ctx: &mut Context) -> i32 {
     let esp = ctx.cpu.regs.esp;
     let dst = ctx.memory.read::<u32>(esp + 4);
     let fmt_addr = ctx.memory.read::<u32>(esp + 8);
-    let fmt = ctx.memory.read_str(fmt_addr).to_owned();
+    let fmt = ctx.memory.read_cstr(fmt_addr).to_vec();
     let mut arg_addr = esp + 12;
 
-    let bytes = fmt.as_bytes();
+    let bytes = fmt.as_slice();
     let mut out: Vec<u8> = Vec::new();
     let mut i = 0;
     while i < bytes.len() {
@@ -229,7 +229,7 @@ pub fn wsprintfA(ctx: &mut Context) -> i32 {
             b'c' => vec![next_arg() as u8],
             b's' => {
                 let addr = next_arg();
-                ctx.memory.read_str(addr).as_bytes().to_vec()
+                ctx.memory.read_cstr(addr).to_vec()
             }
             _ => {
                 // Consume the arg anyway: skipping it would shift every

--- a/win32/winapi/src/winmm/mmio.rs
+++ b/win32/winapi/src/winmm/mmio.rs
@@ -154,7 +154,7 @@ pub fn mmioOpenA(ctx: &mut Context, szFilename: u32, _lpmmioinfo: u32, _dwOpenFl
         log::warn!("mmioOpenA: no filename");
         return 0;
     }
-    let name = ctx.memory.read_str(szFilename).to_owned();
+    let name = ctx.memory.read_str(szFilename).into_owned();
     let path = kernel32::resolve_path(&name);
     let data = match host::fs::read(&path) {
         Ok(data) => data,


### PR DESCRIPTION
This fixes Moto Racer which has a copyright symbol in the window title 😁 

I think that using a `Cow` was quite smart, and it is a quite small patch. But potentially we'd want to _always_ read the strings as Windows-1252 maybe? 🤔 

From Claude Fable 5.1 (high):

> Programs of this era use Windows-1252, and a window title with a copyright sign in it took read_str's from_utf8 unwrap down. read_str now returns a Cow: borrowed for valid UTF-8, an owned Latin-1 decode otherwise.
>
> The first commit adds Memory::read_cstr and moves the byte-oriented callers onto it (lstrlen/lstrcpy/lstrcat, wsprintfA, the NLS length computations), so decoding never changes a length or re-encodes a copy.